### PR TITLE
[SPEC-7801] Move AWSGameLiftServerSDK from perforce to github

### DIFF
--- a/package-system/AWSGameLiftServerSDK/.gitignore
+++ b/package-system/AWSGameLiftServerSDK/.gitignore
@@ -1,0 +1,2 @@
+linux/AWSGameLiftServerSDK/*
+windows/AWSGameLiftServerSDK/*

--- a/package-system/AWSGameLiftServerSDK/AWSGameLiftServerSDK_3.4.1.patch
+++ b/package-system/AWSGameLiftServerSDK/AWSGameLiftServerSDK_3.4.1.patch
@@ -1,0 +1,20 @@
+diff --git a/cmake/External_boost.cmake b/cmake/External_boost.cmake
+index 6fc990b..4625648 100644
+--- a/cmake/External_boost.cmake
++++ b/cmake/External_boost.cmake
+@@ -66,8 +66,14 @@ if(use_bat)
+     BUILD_COMMAND b2 address-model=${am} ${boost_with_args}
+   )
+ else()
++  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
++    set(_build_variant "debug")
++  else()
++    set(_build_variant  "release")
++  endif()
++
+   list(APPEND boost_with_args
+-    "cxxflags=-fPIC")
++    "cxxflags=-fPIC" "toolset=clang-6.0" "variant=${_build_variant}")
+   set(boost_cmds
+     CONFIGURE_COMMAND ./bootstrap.sh --prefix=<INSTALL_DIR>
+     BUILD_COMMAND ./b2 address-model=${am} ${boost_with_args}

--- a/package-system/AWSGameLiftServerSDK/README.md
+++ b/package-system/AWSGameLiftServerSDK/README.md
@@ -1,0 +1,117 @@
+# GameLiftServerSdk C++
+## Documentation
+You can find the official GameLift documentation [here](https://aws.amazon.com/documentation/gamelift/).
+
+## Minimum requirements:
+* Either of the following:  
+  * Microsoft Visual Studio 2017 - Windows Build
+  * Clang 6.0 - Linux Build
+* CMake version 3.1 or later
+* Python version 3.6 or later
+* A Git client available on the PATH
+
+## Build the GameLiftServerSdk - Windows
+1. Download the latest [GameLift Server SDK](https://aws.amazon.com/gamelift/getting-started/) 
+   and unzip source `GameLift-Cpp-ServerSDK-{version-number}`
+   
+2. Copy and put `package-system/AWSGameLiftServerSDK/build_and_package.py` and `package-system/AWSGameLiftServerSDK/gamelift-sdk.json` 
+   into `GameLift-Cpp-ServerSDK-{version-number}` directory in step 1
+   
+3. Run the python script `build_and_package.py` under `GameLift-Cpp-ServerSDK-{version-number}` directory, like
+   ```
+   & python build_and_package.py --config gamelift-sdk.json --platform windows --version 3.4.1
+   ```
+   
+4. Build package will be located under `GameLift-Cpp-ServerSDK-{version-number}/build/{version-number}` directory
+
+5. Copy and put build package into `package-system/AWSGameLiftServerSDK/windows/AWSGameLiftServerSDK`, for example
+   ``` 
+   - AWSGameLiftServerSDK
+     - bin
+     - include
+     - lib
+     - LICENSE_AMAZON_GAMELIFT_SDK.txt
+     - NOTICE_C++_AMAZON_GAMELIFT_SDK.txt
+   ```
+6. Update `package-system/AWSGameLiftServerSDK/windows/PackageInfo.json` with built version `PackageName`
+
+7. Update `<3p-package-source path>/package_build_list_host_windows.json` with updated `PackageName` in step 6
+
+## Build the GameLiftServerSdk - Linux
+1. Download the latest [GameLift Server SDK](https://aws.amazon.com/gamelift/getting-started/) 
+   and unzip source `GameLift-Cpp-ServerSDK-{version-number}`
+    
+2. Copy and put `package-system/AWSGameLiftServerSDK/build_and_package.py`, `package-system/AWSGameLiftServerSDK/gamelift-sdk.json` 
+   and `package-system/AWSGameLiftServerSDK/AWSGameLiftServerSDK_3.4.1.patch` into `GameLift-Cpp-ServerSDK-{version-number}` directory in step 1
+
+3. Link Clang compiler for cmake build (if `/usr/bin/clang` and `/usr/bin/clang++` symlink exist already, 
+   please remove them first `sudo rm /usr/bin/clang /usr/bin/clang++`)
+   ```
+   $ sudo ln -s /usr/bin/clang-6.0 /usr/bin/clang
+   ```
+   ```
+   $ sudo ln -s /usr/bin/clang++-6.0 /usr/bin/clang++ 
+   ```
+
+4. Patch `External_boost.cmake` under `GameLift-Cpp-ServerSDK-{version-number}/cmake`
+   to make sure boost library get build with correct toolset (clang-6.0 for example) and variants
+   * Under `GameLift-Cpp-ServerSDK-{version-number}` directory, run command `git init` to init a local git repository with current directory
+   * Run command `git add .` to stage all existing files
+   * Run command `git commit -m "init commit"` to commit your existing files
+   * Run command `git apply --ignore-space-change --ignore-whitespace AWSGameLiftServerSDK_3.4.1.patch` to apply patch 
+   * Run command `git diff` to check expected changes like
+     ```diff
+          BUILD_COMMAND b2 address-model=${am} ${boost_with_args}
+        )
+      else()
+     +  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+     +    set(_build_variant "debug")
+     +  else()
+     +    set(_build_variant  "release")
+     +  endif()
+     +
+        list(APPEND boost_with_args
+     -    "cxxflags=-fPIC")
+     +    "cxxflags=-fPIC" "toolset=clang-6.0" "variant=${_build_variant}")
+        set(boost_cmds
+          CONFIGURE_COMMAND ./bootstrap.sh --prefix=<INSTALL_DIR>
+          BUILD_COMMAND ./b2 address-model=${am} ${boost_with_args}
+     ```
+
+5. Run the python script `build_and_package.py` under `GameLift-Cpp-ServerSDK-{version-number}` directory, like
+   ```
+   & python3 build_and_package.py --config gamelift-sdk.json --platform linux --version 3.4.1
+   ```
+
+6. Build package will be located under `GameLift-Cpp-ServerSDK-{version-number}/build/{version-number}` directory
+
+7. Copy and put build package into `package-system/AWSGameLiftServerSDK/linux/AWSGameLiftServerSDK`, for example
+   ``` 
+   - AWSGameLiftServerSDK
+     - include
+     - lib
+     - LICENSE_AMAZON_GAMELIFT_SDK.txt
+     - NOTICE_C++_AMAZON_GAMELIFT_SDK.txt
+   ```
+8. Update `package-system/AWSGameLiftServerSDK/linux/PackageInfo.json` with built version `PackageName`
+
+9. Update `<3p-package-source path>/package_build_list_host_linux.json` with updated `PackageName` in step 6
+
+## FAQ
+* For windows build, use `--msbuild_path` argument to specify msbuild executable path if msbuild is unrecognized as a valid command, like
+  ```
+  & python build_and_package.py --config gamelift-sdk.json --platform windows --version 3.4.1 --msbuild_path "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
+  ```
+
+* For windows build, if you get error message `The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters`
+  Please move `GameLift-Cpp-ServerSDK-{version-number}` directory out of nested directories and retry.
+
+* This SDK is known to work with these CMake generators:
+  * Visual Studio 15 2017 Win64
+  * Visual Studio 14 2015 Win64
+  * Visual Studio 12 2013 Win64
+  * Visual Studio 11 2012 Win64
+  * Unix MakeFiles
+    
+  By default, we use `vs2017` for windows build and `clang-6.0` for linux build.
+  Please update `gamelift-sdk.json` platform configs: **archs** and **toolchains** if need to change cmake generator.

--- a/package-system/AWSGameLiftServerSDK/build_and_package.py
+++ b/package-system/AWSGameLiftServerSDK/build_and_package.py
@@ -1,0 +1,290 @@
+#
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
+#
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+import argparse
+import atexit
+import itertools
+import json
+import os
+import shutil
+import sys
+
+from contextlib import contextmanager
+
+
+def ParseArguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--version', required=True, help='The version number of GameLiftServerSDK, e.g. 3.4.1')
+    parser.add_argument('--platform', required=True, choices=['windows', 'linux'])
+    parser.add_argument('--config', required=True, help='gamelift-sdk.json')
+    parser.add_argument('--msbuild_path', help='msbuild executable path for windows platform')
+
+    return parser.parse_args()
+
+@contextmanager
+def InDirectory(path):
+    prev = os.getcwd()
+    os.chdir(path)
+    yield
+    os.chdir(prev)
+
+class Variant:
+    """
+    Variant class is used to store variants info for cmake build
+    """
+    def __init__(self, platform, arch, toolchain, config, libtype):
+        self.platform = platform
+        self.arch = arch
+        self.toolchain = toolchain
+        self.config = config
+        self.libtype = libtype
+
+    def __str__(self):
+        return f'{self.arch}-{self.toolchain}-{self.config}-{self.libtype}'
+
+    __repr__ = __str__
+
+    def GetPath(self):
+        return str(self)
+
+    def GetGenerateProjectsCommand(self):
+        return f'cmake {self.platform.GetCMakeDefines(self)} {self.platform.GetCMakeGenerator(self)} ..{os.sep}..'
+
+    def GenerateProjects(self):
+        projectPath = self.GetPath()
+        os.makedirs(projectPath, exist_ok=True)
+
+        with InDirectory(projectPath):
+            return os.system(self.GetGenerateProjectsCommand())
+
+        # shouldn't get here, but there is a chance the chdir could fail
+        return 1
+
+    def GetBuildCommand(self):
+        return self.platform.GetBuildCommand(self)
+
+    def Build(self):
+        with InDirectory(self.GetPath()):
+            return os.system(self.GetBuildCommand())
+
+    @property
+    def lib_extension(self):
+        return self.platform.lib_extension
+
+    @property
+    def lib_prefix(self):
+        return 'lib' if self.platform.name == 'Linux' else ''
+
+    @property
+    def shared_lib_extension(self):
+        return self.platform.shared_lib_extension
+
+    @property
+    def lib_config_suffix(self):
+        return 'd' if self.config == 'Debug' and self.platform.name == 'Windows' else ''
+
+class Platform(object):
+    """
+    Platform class is used to store platform related configs for cmake build
+    """
+    def __init__(self, archs, toolchains, configs, libtypes):
+        self.archs = archs
+        self.toolchains = toolchains
+        self.configs = configs
+        self.libtypes = libtypes
+
+    def GetVariants(self):
+        for variant in itertools.product(*[self.archs, self.toolchains, self.configs, self.libtypes]):
+            yield Variant(self, variant[0], variant[1], variant[2], variant[3])
+
+    def GetCMakeGenerator(self, variant):
+        return ''
+
+    def GetCMakeDefines(self, variant):
+        cmakeDefines = ''
+        if variant.libtype == 'Shared':
+            cmakeDefines += '-DBUILD_SHARED_LIBS=1'
+
+        if variant.config == 'Debug':
+            cmakeDefines += ' -DCMAKE_BUILD_TYPE=Debug'
+
+        return cmakeDefines
+
+class WindowsPlatform(Platform):
+    """
+    WindowsPlatform is used to store windows specific platform configs
+    """
+    def __init__(self, archs, toolchains, configs, libtypes):
+        super(WindowsPlatform, self).__init__(archs, toolchains, configs, libtypes)
+        self.name = 'Windows'
+        self.lib_extension = 'lib'
+        self.shared_lib_extension = 'dll'
+        self.msbuild_path = 'msbuild'
+
+    def GetCMakeGenerator(self, variant):
+        return '-G "Visual Studio 15 2017 Win64"'
+
+    def GetBuildCommand(self, variant):
+        return f'{self.msbuild_path} ALL_BUILD.vcxproj /p:Configuration={variant.config}'
+        
+    def SetMSBuildPath(self, msbuild_path):
+        self.msbuild_path = msbuild_path
+
+class LinuxPlatform(Platform):
+    """
+    LinuxPlatform is used to store linux specific platform configs
+    """
+    def __init__(self, archs, toolchains, configs, libtypes):
+        super(LinuxPlatform, self).__init__(archs, toolchains, configs, libtypes)
+        self.name = 'Linux'
+        self.lib_extension = 'a'
+        self.shared_lib_extension = 'so'
+
+    def GetCMakeGenerator(self, variant):
+        return '-G "Unix Makefiles"'
+
+    def GetCMakeDefines(self, variant):
+        # it is necessary until GameLift sdk cmake properly supports clang or passin
+        if variant.toolchain.startswith('clang'):
+            os.environ['CC'] = 'clang'
+            os.environ['CXX'] = 'clang++'
+            os.environ['CXXFLAGS'] = '-fPIC'
+
+        defines = super(LinuxPlatform, self).GetCMakeDefines(variant)
+        return defines
+
+    def GetBuildCommand(self, variant):
+        return 'make'
+
+class Package:
+    """
+    Package class is used to package the expected files defined in gamelift-sdk.json from build process
+    """
+    def __init__(self, outputDir, version, noArchFiles, variantFiles, variantSharedFiles, staticLibOutputDir, sharedLibOutputDir):
+        self.outputDir = outputDir
+        self.version = version
+        self.noArchFiles = noArchFiles
+        self.variantFiles = variantFiles
+        self.variantSharedFiles = variantSharedFiles
+        self.staticLibOutputDir = staticLibOutputDir
+        self.sharedLibOutputDir = sharedLibOutputDir
+        self.variants = []
+
+    def AddVariant(self, variant):
+        self.variants.append(variant)
+
+    def Populate(self):
+        packageDir = os.path.join(self.outputDir, self.version)
+
+        # remove any existing package dir
+        if os.path.isdir(packageDir):
+            shutil.rmtree(packageDir)
+
+        # create package outdir
+        try:
+            os.mkdir(packageDir)
+        except OSError:
+            print(f'[Error] failed to properly create package dir {packageDir}')
+            return
+
+        for fileName in self.noArchFiles:
+            self.SmartCopy(fileName, packageDir)
+
+        # copy built libs by variant
+        for variant in self.variants:
+            self.InstallVariant(variant, packageDir)
+
+    def InstallVariant(self, variant, outdir):
+        libDir = self.sharedLibOutputDir if variant.libtype == 'Shared' else self.staticLibOutputDir
+
+        variantOutdir = os.path.join(outdir, libDir, variant.arch, variant.toolchain, variant.config)
+        os.makedirs(variantOutdir)
+
+        for fileNameFormat in self.variantFiles:
+            fileName = os.path.normpath(os.path.join(self.outputDir, variant.GetPath(), fileNameFormat.format(variant)))
+            self.SmartCopy(fileName, variantOutdir)
+
+        if variant.libtype == 'Shared':
+            for fileNameFormat in self.variantSharedFiles:
+                fileName = os.path.normpath(os.path.join(self.outputDir, variant.GetPath(), fileNameFormat.format(variant)))
+                self.SmartCopy(fileName, variantOutdir)
+
+    def SmartCopy(self, src, dst):
+        if os.path.isdir(src):
+            newdst = os.path.join(dst, os.path.basename(src))
+            print(f'Copying Tree: {src} ==> {newdst}')
+            shutil.copytree(src, newdst)
+        else:
+            print(f'Copying: {src} ==> {dst}')
+            shutil.copy2(src, dst)
+
+def main():
+    args = ParseArguments()
+
+    if not os.path.isfile(args.config):
+        print(f'Invalid config file: {args.config}')
+        exit(1)
+
+    with open(args.config) as configFile:
+        jsonConfig = json.load(configFile)
+
+    outputDir = jsonConfig["OutputDir"]
+    os.makedirs(outputDir, exist_ok=True)
+
+    if args.platform == "windows":
+        platformConfig = jsonConfig["Platforms"]["Windows"]
+        platformFactory = WindowsPlatform
+    else:
+        platformConfig = jsonConfig["Platforms"]["Linux"]
+        platformFactory = LinuxPlatform
+
+    platform = platformFactory(platformConfig["archs"], platformConfig["toolchains"], platformConfig["configs"], platformConfig["libtypes"])
+    if args.msbuild_path:
+        platform.SetMSBuildPath(f'"{args.msbuild_path}"')
+
+    package = Package(outputDir, args.version, jsonConfig["NoArchFiles"], jsonConfig["VariantFiles"], jsonConfig["VariantSharedFiles"],
+        jsonConfig["StaticLibOutputDir"], jsonConfig["SharedLibOutputDir"])
+    projectIssues = []
+    buildIssues = []
+
+    # Create projects and build
+    with InDirectory(outputDir):
+        for variant in platform.GetVariants():
+            print()
+            print(f'########### {variant} ###########')
+
+            print(f'Running: {variant.GetGenerateProjectsCommand()}')
+            projectResult = variant.GenerateProjects()
+            if projectResult != 0:
+                projectIssues.append(variant)
+            else:
+                print(f'Running: {variant.GetBuildCommand()}')
+                buildResult = variant.Build()
+                if buildResult != 0:
+                   buildIssues.append(variant)
+
+            package.AddVariant(variant)
+
+        print()
+        print('########### Report ###########')
+        print(f'Project failures: {projectIssues}')
+        print(f'Build failures: {buildIssues}')
+
+    print()
+    if len(projectIssues) == 0 and len(buildIssues) == 0:
+        package.Populate()
+        print(f'Package "{args.version}" created in directory "{outputDir}"')
+    else:
+        print('Skipping package creation due to build errors.')
+
+if __name__ == '__main__':
+    main()
+

--- a/package-system/AWSGameLiftServerSDK/gamelift-sdk.json
+++ b/package-system/AWSGameLiftServerSDK/gamelift-sdk.json
@@ -1,0 +1,46 @@
+{
+    "OutputDir": "build",
+    "StaticLibOutputDir": "lib",
+    "SharedLibOutputDir": "bin",
+
+    "Platforms":
+    {
+        "Windows":
+        {
+            "archs"     : ["intel64"],
+            "toolchains": ["msvc-14.1"],
+            "configs"   : ["Debug", "Release"],
+            "libtypes"  : ["Shared", "Static"]
+        },
+
+        "Linux":
+        {
+            "archs"     : ["intel64"],
+            "toolchains": ["clang-6.0"],
+            "configs"   : ["Debug", "Release"],
+            "libtypes"  : ["Static"]
+        }
+    },
+
+    "NoArchFiles":
+    [
+        "gamelift-server-sdk/include",
+        "NOTICE_C++_AMAZON_GAMELIFT_SDK.TXT",
+        "LICENSE_AMAZON_GAMELIFT_SDK.TXT"
+    ],
+
+    "VariantFiles":
+    [
+        "prefix/lib/libboost_date_time.{0.lib_extension}",
+        "prefix/lib/libboost_random.{0.lib_extension}",
+        "prefix/lib/libboost_system.{0.lib_extension}",
+        "prefix/lib/libprotobuf{0.lib_config_suffix}.{0.lib_extension}",
+        "prefix/lib/{0.lib_prefix}sioclient.{0.lib_extension}",
+        "prefix/lib/{0.lib_prefix}aws-cpp-sdk-gamelift-server.{0.lib_extension}"
+    ], 
+
+    "VariantSharedFiles":
+    [
+        "prefix/bin/{0.lib_prefix}aws-cpp-sdk-gamelift-server.{0.shared_lib_extension}"
+    ]
+}

--- a/package-system/AWSGameLiftServerSDK/linux/FindAWSGameLiftServerSDK.cmake
+++ b/package-system/AWSGameLiftServerSDK/linux/FindAWSGameLiftServerSDK.cmake
@@ -1,0 +1,57 @@
+#
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
+#
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+set(TARGET_WITH_NAMESPACE "3rdParty::AWSGameLiftServerSDK")
+if (TARGET ${TARGET_WITH_NAMESPACE})
+    return()
+endif()
+
+set(LIB_NAME "AWSGameLiftServerSDK")
+
+set(${LIB_NAME}_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/${LIB_NAME}/include)
+set(${LIB_NAME}_LIBS_DIR ${CMAKE_CURRENT_LIST_DIR}/${LIB_NAME}/lib)
+
+set(AWSGAMELIFTSERVERSDK_LIB_PATH ${${LIB_NAME}_LIBS_DIR}/intel64/clang-6.0/$<IF:$<CONFIG:Debug>,Debug,Release>)
+
+set(AWSGAMELIFTSERVERSDK_LIBS
+    ${AWSGAMELIFTSERVERSDK_LIB_PATH}/libaws-cpp-sdk-gamelift-server.a
+    ${AWSGAMELIFTSERVERSDK_LIB_PATH}/libsioclient.a
+    ${AWSGAMELIFTSERVERSDK_LIB_PATH}/libboost_date_time.a
+    ${AWSGAMELIFTSERVERSDK_LIB_PATH}/libboost_random.a
+    ${AWSGAMELIFTSERVERSDK_LIB_PATH}/libboost_system.a
+    ${AWSGAMELIFTSERVERSDK_LIB_PATH}/libprotobuf.a
+)
+
+set(AWSGAMELIFTSERVERSDK_COMPILE_DEFINITIONS
+    AWS_CUSTOM_MEMORY_MANAGEMENT
+    BUILD_GAMELIFT_SERVER
+    PLATFORM_SUPPORTS_AWS_NATIVE_SDK
+    GAMELIFT_USE_STD
+)
+
+if (NOT LY_MONOLITHIC_GAME)
+    # Add 'USE_IMPORT_EXPORT' for external linkage
+    LIST(APPEND AWSGAMELIFTSERVERSDK_COMPILE_DEFINITIONS USE_IMPORT_EXPORT)
+endif()
+
+# Declare target
+add_library(${TARGET_WITH_NAMESPACE} INTERFACE IMPORTED GLOBAL)
+
+# Add include folder
+ly_target_include_system_directories(TARGET ${TARGET_WITH_NAMESPACE} INTERFACE ${${LIB_NAME}_INCLUDE_DIR})
+
+# Add link libs
+target_link_libraries(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSGAMELIFTSERVERSDK_LIBS})
+
+# Set compile definitions
+target_compile_definitions(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSGAMELIFTSERVERSDK_COMPILE_DEFINITIONS})
+
+set(${LIB_NAME}_FOUND True)

--- a/package-system/AWSGameLiftServerSDK/linux/PackageInfo.json
+++ b/package-system/AWSGameLiftServerSDK/linux/PackageInfo.json
@@ -1,0 +1,6 @@
+{
+    "PackageName" : "AWSGameLiftServerSDK-3.4.1-rev1-linux",
+    "URL"         : "https://aws.amazon.com/documentation/gamelift/",
+    "License"     : "Apache-2.0",
+    "LicenseFile" : "AWSGameLiftServerSDK/LICENSE_AMAZON_GAMELIFT_SDK.TXT"
+}

--- a/package-system/AWSGameLiftServerSDK/windows/FindAWSGameLiftServerSDK.cmake
+++ b/package-system/AWSGameLiftServerSDK/windows/FindAWSGameLiftServerSDK.cmake
@@ -1,0 +1,71 @@
+#
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
+#
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+set(TARGET_WITH_NAMESPACE "3rdParty::AWSGameLiftServerSDK")
+if (TARGET ${TARGET_WITH_NAMESPACE})
+    return()
+endif()
+
+set(LIB_NAME "AWSGameLiftServerSDK")
+
+set(${LIB_NAME}_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/${LIB_NAME}/include)
+set(${LIB_NAME}_BIN_DIR ${CMAKE_CURRENT_LIST_DIR}/${LIB_NAME}/bin)
+set(${LIB_NAME}_LIBS_DIR ${CMAKE_CURRENT_LIST_DIR}/${LIB_NAME}/lib)
+
+if (LY_MONOLITHIC_GAME)
+    # Import libs path
+    set(AWSGAMELIFTSERVERSDK_LIB_PATH ${${LIB_NAME}_LIBS_DIR}/intel64/msvc-14.1/$<IF:$<CONFIG:Debug>,Debug,Release>)
+else()
+    # Static libs path
+    set(AWSGAMELIFTSERVERSDK_LIB_PATH ${${LIB_NAME}_BIN_DIR}/intel64/msvc-14.1/$<IF:$<CONFIG:Debug>,Debug,Release>)
+endif()
+
+set(AWSGAMELIFTSERVERSDK_LIBS
+    ${AWSGAMELIFTSERVERSDK_LIB_PATH}/sioclient.lib
+    ${AWSGAMELIFTSERVERSDK_LIB_PATH}/libboost_date_time.lib
+    ${AWSGAMELIFTSERVERSDK_LIB_PATH}/libboost_random.lib
+    ${AWSGAMELIFTSERVERSDK_LIB_PATH}/libboost_system.lib
+    ${AWSGAMELIFTSERVERSDK_LIB_PATH}/libprotobuf$<$<CONFIG:Debug>:d>.lib
+    ${AWSGAMELIFTSERVERSDK_LIB_PATH}/aws-cpp-sdk-gamelift-server.lib
+)
+
+set(AWSGAMELIFTSERVERSDK_COMPILE_DEFINITIONS
+    AWS_CUSTOM_MEMORY_MANAGEMENT
+    BUILD_GAMELIFT_SERVER
+    PLATFORM_SUPPORTS_AWS_NATIVE_SDK
+    GAMELIFT_USE_STD
+)
+
+if (NOT LY_MONOLITHIC_GAME)
+    # Add 'USE_IMPORT_EXPORT' for external linkage
+    LIST(APPEND AWSGAMELIFTSERVERSDK_COMPILE_DEFINITIONS USE_IMPORT_EXPORT)
+    # Runtime dependencies
+    set(AWSGAMELIFTSERVERSDK_RUNTIME_DEPENDENCIES ${AWSGAMELIFTSERVERSDK_LIB_PATH}/aws-cpp-sdk-gamelift-server.dll)
+endif()
+
+# Declare target
+add_library(${TARGET_WITH_NAMESPACE} INTERFACE IMPORTED GLOBAL)
+
+# Add include folder
+ly_target_include_system_directories(TARGET ${TARGET_WITH_NAMESPACE} INTERFACE ${${LIB_NAME}_INCLUDE_DIR})
+
+# Add link libs
+target_link_libraries(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSGAMELIFTSERVERSDK_LIBS})
+
+# Add runtime dependencies if defined
+if(DEFINED AWSGAMELIFTSERVERSDK_RUNTIME_DEPENDENCIES)
+    ly_add_dependencies(${TARGET_WITH_NAMESPACE} ${AWSGAMELIFTSERVERSDK_RUNTIME_DEPENDENCIES})
+endif()
+
+# Set compile definitions
+target_compile_definitions(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSGAMELIFTSERVERSDK_COMPILE_DEFINITIONS})
+
+set(${LIB_NAME}_FOUND True)

--- a/package-system/AWSGameLiftServerSDK/windows/PackageInfo.json
+++ b/package-system/AWSGameLiftServerSDK/windows/PackageInfo.json
@@ -1,0 +1,6 @@
+{
+    "PackageName" : "AWSGameLiftServerSDK-3.4.1-rev1-windows",
+    "URL"         : "https://aws.amazon.com/documentation/gamelift/",
+    "License"     : "Apache-2.0",
+    "LicenseFile" : "AWSGameLiftServerSDK/LICENSE_AMAZON_GAMELIFT_SDK.TXT"
+}


### PR DESCRIPTION
## Details
1. Move existing PackageInfo.json, FindAWSGameLiftServerSDK.cmake, build_and_package.py and gamelift-sdk.json from perforce
2. Update ReadMe with detailed instructions for windows and linux build as phase 1 conversion
3. Add `AWSGameLiftServerSDK_3.4.1.patch` so operator can apply patches easily with command

## Testings
Tested locally to make sure instructions are accurate

Signed-off-by: Liu <liug@amazon.com>