### PR TITLE
Move 3p AWSNativeSDK windows to github

### DIFF
--- a/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Windows.template
+++ b/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Windows.template
@@ -1,0 +1,332 @@
+#
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
+#
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+include(CMakeParseArguments)
+
+set(AWSNATIVESDK_PACKAGE_NAME AWSNativeSDK)
+
+set(AWS_BASE_PATH $${CMAKE_CURRENT_LIST_DIR}/$${AWSNATIVESDK_PACKAGE_NAME})
+
+# Include Path
+set(AWSNATIVESDK_INCLUDE_PATH $${AWS_BASE_PATH}/include)
+
+
+# Determine the lib path and possible bin path
+if (LY_MONOLITHIC_GAME)
+
+    set(AWSNATIVESDK_COMPILE_DEFINITIONS AWS_CUSTOM_MEMORY_MANAGEMENT PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
+    set(AWSNATIVE_SDK_LIB_PATH $${AWS_BASE_PATH}/lib/$$<IF:$$<CONFIG:Debug>,Debug,Release>)
+    unset(AWSNATIVE_SDK_BIN_PATH)
+
+else()
+
+    set(AWSNATIVESDK_COMPILE_DEFINITIONS AWS_CUSTOM_MEMORY_MANAGEMENT PLATFORM_SUPPORTS_AWS_NATIVE_SDK USE_IMPORT_EXPORT)
+    set(AWSNATIVE_SDK_LIB_PATH $${AWS_BASE_PATH}/bin/$$<IF:$$<CONFIG:Debug>,Debug,Release>)
+    set(AWSNATIVE_SDK_BIN_PATH $${AWS_BASE_PATH}/bin/$$<IF:$$<CONFIG:Debug>,Debug,Release>)
+
+endif()
+
+# Helper function to define individual AWSNativeSDK Libraries
+function(ly_declare_aws_library)
+
+    set(options)
+    set(oneValueArgs NAME LIB_FILE)
+    set(multiValueArgs BUILD_DEPENDENCIES)
+    
+    cmake_parse_arguments(ly_declare_aws_library "$${options}" "$${oneValueArgs}" "$${multiValueArgs}" $${ARGN})
+
+    set(TARGET_WITH_NAMESPACE "3rdParty::$${AWSNATIVESDK_PACKAGE_NAME}::$${ly_declare_aws_library_NAME}")
+    if (NOT TARGET $${TARGET_WITH_NAMESPACE})
+
+        add_library($${TARGET_WITH_NAMESPACE} INTERFACE IMPORTED GLOBAL)
+
+        ly_target_include_system_directories(TARGET $${TARGET_WITH_NAMESPACE} INTERFACE $${AWSNATIVESDK_INCLUDE_PATH})
+
+        if (ly_declare_aws_library_LIB_FILE)
+
+            target_link_libraries($${TARGET_WITH_NAMESPACE} 
+                INTERFACE
+                    $${AWSNATIVE_SDK_LIB_PATH}/$${CMAKE_STATIC_LIBRARY_PREFIX}$${ly_declare_aws_library_LIB_FILE}$${CMAKE_STATIC_LIBRARY_SUFFIX}
+                    $${ly_declare_aws_library_BUILD_DEPENDENCIES}
+            )
+
+            if (NOT LY_MONOLITHIC_GAME)
+                ly_add_dependencies($${TARGET_WITH_NAMESPACE} $${AWSNATIVE_SDK_BIN_PATH}/$${CMAKE_SHARED_LIBRARY_PREFIX}$${ly_declare_aws_library_LIB_FILE}$${CMAKE_SHARED_LIBRARY_SUFFIX})
+            endif()
+                    
+        elseif (ly_declare_aws_library_BUILD_DEPENDENCIES)
+            target_link_libraries($${TARGET_WITH_NAMESPACE} 
+                INTERFACE
+                    $${ly_declare_aws_library_BUILD_DEPENDENCIES}
+            )
+        endif()
+        
+        target_link_options($${TARGET_WITH_NAMESPACE} INTERFACE $${AWSNATIVESDK_LINK_OPTIONS})
+
+
+        target_compile_definitions($${TARGET_WITH_NAMESPACE} INTERFACE $${AWSNATIVESDK_COMPILE_DEFINITIONS})
+
+    endif()
+    
+endfunction()
+
+
+#### Common ####
+ly_declare_aws_library(
+    NAME 
+        Common
+    LIB_FILE 
+        aws-c-common
+    BUILD_DEPENDENCIES
+        Bcrypt.lib
+        Userenv.lib
+        Version.lib
+        Wininet.lib
+        Winhttp.lib
+        Ws2_32.lib            
+)       
+
+#### Checksums ####
+ly_declare_aws_library(
+    NAME 
+        Checksums
+    LIB_FILE 
+        aws-checksums
+)
+
+#### EventStream ####
+ly_declare_aws_library(
+    NAME 
+        EventStream
+    LIB_FILE 
+        aws-c-event-stream
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Checksums
+)
+
+#### Core ####
+ly_declare_aws_library(
+    NAME 
+        Core
+    LIB_FILE 
+        aws-cpp-sdk-core
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Common
+        3rdParty::AWSNativeSDK::EventStream
+)
+
+#### AccessManagement ####
+ly_declare_aws_library(
+    NAME 
+        AccessManagement
+    LIB_FILE 
+        aws-cpp-sdk-access-management
+)
+
+#### CognitoIdentity ####
+ly_declare_aws_library(
+    NAME 
+        CognitoIdentity
+    LIB_FILE 
+        aws-cpp-sdk-cognito-identity
+)
+
+#### CognitoIdp ####
+ly_declare_aws_library(
+    NAME 
+        CognitoIdp
+    LIB_FILE 
+        aws-cpp-sdk-cognito-idp
+)
+
+#### DeviceFarm ####
+ly_declare_aws_library(
+    NAME 
+        DeviceFarm
+    LIB_FILE 
+        aws-cpp-sdk-devicefarm
+)
+
+#### DynamoDB ####
+ly_declare_aws_library(
+    NAME 
+        DynamoDB
+    LIB_FILE 
+        aws-cpp-sdk-dynamodb
+)
+
+#### GameLift ####
+ly_declare_aws_library(
+    NAME 
+        GameLift
+    LIB_FILE 
+        aws-cpp-sdk-gamelift
+)
+
+#### IdentityManagement ####
+ly_declare_aws_library(
+    NAME 
+        IdentityManagement
+    LIB_FILE 
+        aws-cpp-sdk-identity-management
+)
+
+#### Kinesis ####
+ly_declare_aws_library(
+    NAME 
+        Kinesis
+    LIB_FILE 
+        aws-cpp-sdk-kinesis
+)
+
+#### Lambda ####
+ly_declare_aws_library(
+    NAME 
+        Lambda
+    LIB_FILE 
+        aws-cpp-sdk-lambda
+)
+
+#### MobileAnalytics ####
+ly_declare_aws_library(
+    NAME 
+        MobileAnalytics
+    LIB_FILE 
+        aws-cpp-sdk-mobileanalytics
+)
+
+#### Queues ####
+ly_declare_aws_library(
+    NAME 
+        Queues
+    LIB_FILE 
+        aws-cpp-sdk-queues
+)
+
+#### S3 ####
+ly_declare_aws_library(
+    NAME 
+        S3
+    LIB_FILE 
+        aws-cpp-sdk-s3
+)
+
+#### SNS ####
+ly_declare_aws_library(
+    NAME 
+        SNS
+    LIB_FILE 
+        aws-cpp-sdk-sns
+)
+
+#### SQS ####
+ly_declare_aws_library(
+    NAME 
+        SQS
+    LIB_FILE 
+        aws-cpp-sdk-sqs
+)
+
+#### STS ####
+ly_declare_aws_library(
+    NAME 
+        STS
+    LIB_FILE 
+        aws-cpp-sdk-sts
+)
+
+#### Transfer ####
+ly_declare_aws_library(
+    NAME 
+        Transfer
+    LIB_FILE 
+        aws-cpp-sdk-transfer
+)
+
+
+#########
+######### Grouping Definitions #########
+#########
+
+
+#### Dependencies ####
+ly_declare_aws_library(
+    NAME 
+        Dependencies
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Checksums
+        3rdParty::AWSNativeSDK::Common
+        3rdParty::AWSNativeSDK::EventStream
+)
+
+#### IdentityMetrics ####
+ly_declare_aws_library(
+    NAME 
+        IdentityMetrics
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Dependencies
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::IdentityManagement
+        3rdParty::AWSNativeSDK::STS
+        3rdParty::AWSNativeSDK::MobileAnalytics
+)
+
+#### IdentityLambda ####
+ly_declare_aws_library(
+    NAME 
+        IdentityLambda
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Dependencies
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::IdentityManagement
+        3rdParty::AWSNativeSDK::Lambda
+        3rdParty::AWSNativeSDK::STS
+)
+
+#### GameLiftClient ####
+ly_declare_aws_library(
+    NAME 
+        GameLiftClient
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::GameLift
+        3rdParty::AWSNativeSDK::Dependencies
+)
+
+#### AWSClientAuth ####
+ly_declare_aws_library(
+    NAME 
+        AWSClientAuth
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Dependencies
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::STS
+        3rdParty::AWSNativeSDK::IdentityManagement
+)
+
+
+#### AWSCore ####
+ly_declare_aws_library(
+    NAME 
+        AWSCore
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Dependencies
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::DynamoDB
+        3rdParty::AWSNativeSDK::Lambda
+        3rdParty::AWSNativeSDK::S3
+)
+

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_windows.cmd
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_windows.cmd
@@ -14,15 +14,27 @@ call::GenerateCommonCMakeArgs CMAKE_COMMON_ARGS
 
 REM Debug Shared
 call:ConfigureAndBuild Debug Shared
+IF %ERRORLEVEL% NEQ 0 (
+    exit /b 1
+)
 
 REM Debug Static
 call:ConfigureAndBuild Debug Static
+IF %ERRORLEVEL% NEQ 0 (
+    exit /b 1
+)
 
 REM Release Shared
 call:ConfigureAndBuild Release Shared
+IF %ERRORLEVEL% NEQ 0 (
+    exit /b 1
+)
 
 REM Release Static
 call:ConfigureAndBuild Release Static
+IF %ERRORLEVEL% NEQ 0 (
+    exit /b 1
+)
 
 ECHO "Custom Build for AWSNativeSDK finished successfully"
 exit /b 0

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_windows.cmd
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_windows.cmd
@@ -9,9 +9,6 @@ REM
 SET SRC_PATH=temp\src
 SET BLD_PATH=temp\build
 
-SET CMAKE_COMMON_ARGS=""
-call::GenerateCommonCMakeArgs CMAKE_COMMON_ARGS
-
 REM Debug Shared
 call:ConfigureAndBuild Debug Shared
 IF %ERRORLEVEL% NEQ 0 (
@@ -46,8 +43,19 @@ SET BUILD_SHARED=OFF
 IF %LIB_TYPE% EQU Shared (
     SET BUILD_SHARED=ON
 )
-ECHO "CMake Configure %BUILD_TYPE% %LIB_TYPE% with %CMAKE_COMMON_ARGS%"
-call cmake -S %SRC_PATH% -B %BLD_PATH%\%BUILD_TYPE%_%LIB_TYPE% %CMAKE_COMMON_ARGS% -DBUILD_SHARED_LIBS=%BUILD_SHARED% -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -DCMAKE_INSTALL_BINDIR="bin/%BUILD_TYPE%" -DCMAKE_INSTALL_LIBDIR="lib/%BUILD_TYPE%"
+ECHO "CMake Configure %BUILD_TYPE% %LIB_TYPE%"
+call cmake -S %SRC_PATH% -B %BLD_PATH%\%BUILD_TYPE%_%LIB_TYPE% ^
+           -G "Visual Studio 16 2019" ^
+           -A x64 ^
+           -DCPP_STANDARD=17 ^
+           -DBUILD_ONLY="access-management;cognito-identity;cognito-idp;core;devicefarm;dynamodb;gamelift;identity-management;kinesis;lambda;mobileanalytics;queues;s3;sns;sqs;sts;transfer" ^
+           -DENABLE_TESTING=OFF ^
+           -DENABLE_RTTI=ON ^
+           -DCUSTOM_MEMORY_MANAGEMENT=ON^
+           -DBUILD_SHARED_LIBS=%BUILD_SHARED% ^
+           -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" ^
+           -DCMAKE_INSTALL_BINDIR="bin/%BUILD_TYPE%" ^
+           -DCMAKE_INSTALL_LIBDIR="lib/%BUILD_TYPE%"
 IF %ERRORLEVEL% NEQ 0 (
     ECHO "CMake Configure %BUILD_TYPE% %LIB_TYPE% failed"
     exit /b 1
@@ -59,8 +67,4 @@ IF %ERRORLEVEL% NEQ 0 (
     ECHO "CMake Build %BUILD_TYPE% %LIB_TYPE% to %BLD_PATH%\%BUILD_TYPE%_%LIB_TYPE% failed"
     exit /b 1
 )
-GOTO:EOF
-
-:GenerateCommonCMakeArgs
-SET %~1= -G "Visual Studio 16 2019" -A x64 -DCPP_STANDARD=17 -DBUILD_ONLY="access-management;cognito-identity;cognito-idp;core;devicefarm;dynamodb;gamelift;identity-management;kinesis;lambda;mobileanalytics;queues;s3;sns;sqs;sts;transfer" -DENABLE_TESTING=OFF -DENABLE_RTTI=ON -DCUSTOM_MEMORY_MANAGEMENT=ON
 GOTO:EOF

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_windows.cmd
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_windows.cmd
@@ -1,0 +1,54 @@
+@echo off
+REM 
+REM Copyright (c) Contributors to the Open 3D Engine Project.
+REM For complete copyright and license terms please see the LICENSE at the root of this distribution.
+REM 
+REM SPDX-License-Identifier: Apache-2.0 OR MIT
+REM 
+
+SET SRC_PATH=temp\src
+SET BLD_PATH=temp\build
+
+SET CMAKE_COMMON_ARGS=""
+call::GenerateCommonCMakeArgs CMAKE_COMMON_ARGS
+
+REM Debug Shared
+call:ConfigureAndBuild Debug Shared
+
+REM Debug Static
+call:ConfigureAndBuild Debug Static
+
+REM Release Shared
+call:ConfigureAndBuild Release Shared
+
+REM Release Static
+call:ConfigureAndBuild Release Static
+
+ECHO "Custom Build for AWSNativeSDK finished successfully"
+exit /b 0
+
+:ConfigureAndBuild
+SET BUILD_TYPE=%~1
+SET LIB_TYPE=%~2
+SET BUILD_SHARED=OFF
+IF %LIB_TYPE% EQU Shared (
+    SET BUILD_SHARED=ON
+)
+ECHO "CMake Configure %BUILD_TYPE% %LIB_TYPE% with %CMAKE_COMMON_ARGS%"
+call cmake -S %SRC_PATH% -B %BLD_PATH%\%BUILD_TYPE%_%LIB_TYPE% %CMAKE_COMMON_ARGS% -DBUILD_SHARED_LIBS=%BUILD_SHARED% -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -DCMAKE_INSTALL_BINDIR="bin/%BUILD_TYPE%" -DCMAKE_INSTALL_LIBDIR="lib/%BUILD_TYPE%"
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "CMake Configure %BUILD_TYPE% %LIB_TYPE% failed"
+    exit /b 1
+)
+
+ECHO "CMake Build %BUILD_TYPE% %LIB_TYPE% to %BLD_PATH%\%BUILD_TYPE%_%LIB_TYPE%"
+call cmake --build %BLD_PATH%\%BUILD_TYPE%_%LIB_TYPE% --config %BUILD_TYPE% -j
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "CMake Build %BUILD_TYPE% %LIB_TYPE% to %BLD_PATH%\%BUILD_TYPE%_%LIB_TYPE% failed"
+    exit /b 1
+)
+GOTO:EOF
+
+:GenerateCommonCMakeArgs
+SET %~1= -G "Visual Studio 16 2019" -A x64 -DCPP_STANDARD=17 -DBUILD_ONLY="access-management;cognito-identity;cognito-idp;core;devicefarm;dynamodb;gamelift;identity-management;kinesis;lambda;mobileanalytics;queues;s3;sns;sqs;sts;transfer" -DENABLE_TESTING=OFF -DENABLE_RTTI=ON -DCUSTOM_MEMORY_MANAGEMENT=ON
+GOTO:EOF

--- a/package-system/AWSNativeSDK/build_config.json
+++ b/package-system/AWSNativeSDK/build_config.json
@@ -1,0 +1,25 @@
+{
+   "git_url":"https://github.com/aws/aws-sdk-cpp.git",
+   "git_tag":"1.7.167",
+   "package_name":"AWSNativeSDK",
+   "package_version":"1.7.167-rev3",
+   "package_url":"https://github.com/aws/aws-sdk-cpp",
+   "package_license":"Apache-2.0",
+   "package_license_file":"LICENSE",
+   "cmake_find_target":"FindAWSNativeSDK.cmake",
+   "cmake_find_template_custom_indent": 3,
+   "build_configs": ["Debug", "Release"],
+   "Platforms":{
+      "Windows":{
+         "Windows":{
+            "cmake_find_template":"FindAWSNativeSDK.cmake.Windows.template",
+            "custom_build_cmd": [
+               "build_AWSNativeSDK_windows.cmd"
+            ],
+            "custom_install_cmd": [
+               "install_AWSNativeSDK_windows.cmd"
+            ]
+         }
+      }
+   }
+}

--- a/package-system/AWSNativeSDK/install_AWSNativeSDK_windows.cmd
+++ b/package-system/AWSNativeSDK/install_AWSNativeSDK_windows.cmd
@@ -36,6 +36,9 @@ IF %ERRORLEVEL% NEQ 0 (
     exit /b 1
 )
 call:CopyDynamicAndStaticLibs "Debug"
+IF %ERRORLEVEL% NEQ 0 (
+    exit /b 1
+)
 
 REM CMake Install Release and 3rdParty
 ECHO "CMake Install Release Shared to %INST_PATH%"
@@ -52,6 +55,9 @@ IF %ERRORLEVEL% NEQ 0 (
     exit /b 1
 )
 call:CopyDynamicAndStaticLibs "Release"
+IF %ERRORLEVEL% NEQ 0 (
+    exit /b 1
+)
 
 REM Copy include headers
 ECHO "Copying include headers to %OUT_INCLUDE_PATH%"

--- a/package-system/AWSNativeSDK/install_AWSNativeSDK_windows.cmd
+++ b/package-system/AWSNativeSDK/install_AWSNativeSDK_windows.cmd
@@ -1,0 +1,118 @@
+@echo off
+REM
+REM Copyright (c) Contributors to the Open 3D Engine Project.
+REM For complete copyright and license terms please see the LICENSE at the root of this distribution.
+REM 
+REM SPDX-License-Identifier: Apache-2.0 OR MIT
+REM
+
+SET BLD_PATH=temp\build
+SET SRC_PATH=temp\src
+SET INST_PATH=temp\install
+
+SET OUT_BIN_PATH=%TARGET_INSTALL_ROOT%\bin
+mkdir %OUT_BIN_PATH%\Debug
+mkdir %OUT_BIN_PATH%\Release
+
+SET OUT_INCLUDE_PATH=%TARGET_INSTALL_ROOT%\include
+mkdir %OUT_INCLUDE_PATH%
+
+SET OUT_LIB_PATH=%TARGET_INSTALL_ROOT%\lib
+mkdir %OUT_LIB_PATH%\Debug
+mkdir %OUT_LIB_PATH%\Release
+
+REM CMake Install Debug and 3rdParty
+ECHO "CMake Install Debug Shared to %INST_PATH%"
+call cmake --install %BLD_PATH%\Debug_Shared --prefix %INST_PATH% --config Debug
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "CMake Install Debug Shared to %INST_PATH% failed"
+    exit /b 1
+)
+
+ECHO "CMake Install Debug Static to %INST_PATH%"
+call cmake --install %BLD_PATH%\Debug_Static --prefix %INST_PATH% --config Debug
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "CMake Install Debug Static to %INST_PATH% failed"
+    exit /b 1
+)
+call:CopyDynamicAndStaticLibs "Debug"
+
+REM CMake Install Release and 3rdParty
+ECHO "CMake Install Release Shared to %INST_PATH%"
+call cmake --install %BLD_PATH%\Release_Shared --prefix %INST_PATH% --config Release
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "CMake Install Release Shared to %INST_PATH% failed"
+    exit /b 1
+)
+
+ECHO "CMake Install Release Static to %INST_PATH%"
+call cmake --install %BLD_PATH%\Release_Static --prefix %INST_PATH% --config Release
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "CMake Install Release Static to %INST_PATH% failed"
+    exit /b 1
+)
+call:CopyDynamicAndStaticLibs "Release"
+
+REM Copy include headers
+ECHO "Copying include headers to %OUT_INCLUDE_PATH%"
+Xcopy %INST_PATH%\include\* %OUT_INCLUDE_PATH% /E /Y
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying include headers to %OUT_INCLUDE_PATH% failed"
+    exit /b 1
+)
+
+REM Copy license
+ECHO "Copying LICENSE.TXT to %TARGET_INSTALL_ROOT%"
+copy /Y %SRC_PATH%\LICENSE.TXT %TARGET_INSTALL_ROOT%
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying LICENSE.TXT to %TARGET_INSTALL_ROOT% failed"
+    exit /b 1
+)
+
+ECHO "Custom Install for AWSNativeSDK finished successfully"
+exit /b 0
+
+:CopyDynamicAndStaticLibs
+SET BUILD_TYPE=%~1
+ECHO "Copying shared .dlls to %OUT_BIN_PATH%\%BUILD_TYPE%"
+copy /Y %INST_PATH%\bin\%BUILD_TYPE%\*.dll %OUT_BIN_PATH%\%BUILD_TYPE%\
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying shared .dlls to %OUT_BIN_PATH%\%BUILD_TYPE% failed"
+    exit /b 1
+)
+
+ECHO "Copying shared .libs to %OUT_BIN_PATH%\%BUILD_TYPE%"
+copy /Y %INST_PATH%\bin\%BUILD_TYPE%\*.lib %OUT_BIN_PATH%\%BUILD_TYPE%\
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying shared .libs to %OUT_BIN_PATH%\%BUILD_TYPE% failed"
+    exit /b 1
+)
+
+ECHO "Copying 3rdParty shared .dlls to %OUT_BIN_PATH%\%BUILD_TYPE%"
+copy /Y %BLD_PATH%\%BUILD_TYPE%_Shared\.deps\install\bin\*.dll %OUT_BIN_PATH%\%BUILD_TYPE%\
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying 3rdParty shared .dlls to %OUT_BIN_PATH%\%BUILD_TYPE% failed"
+    exit /b 1
+)
+
+ECHO "Copying 3rdParty shared .libs to %OUT_BIN_PATH%\%BUILD_TYPE%"
+copy /Y %BLD_PATH%\%BUILD_TYPE%_Shared\.deps\install\lib\*.lib %OUT_BIN_PATH%\%BUILD_TYPE%\
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying 3rdParty shared .libs to %OUT_BIN_PATH%\%BUILD_TYPE% failed"
+    exit /b 1
+)
+
+ECHO "Copying static .libs to %OUT_LIB_PATH%\%BUILD_TYPE%"
+copy /Y %INST_PATH%\lib\%BUILD_TYPE%\*.lib %OUT_LIB_PATH%\%BUILD_TYPE%\
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying static .libs to %OUT_LIB_PATH%\%BUILD_TYPE% failed"
+    exit /b 1
+)
+
+ECHO "Copying 3rdParty static .libs to %OUT_LIB_PATH%\%BUILD_TYPE%"
+copy /Y %BLD_PATH%\%BUILD_TYPE%_Static\.deps\install\lib\*.lib %OUT_LIB_PATH%\%BUILD_TYPE%\
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying 3rdParty static .libs to %OUT_LIB_PATH%\%BUILD_TYPE% failed"
+    exit /b 1
+)
+GOTO:EOF


### PR DESCRIPTION
## Details
Still working on other platforms: linux, mac, ios and andoid
1. Move existing FindAWSNativeSDK to github
2. Add custom build and install script for windows

Note: There is no update on AWSNativeSDK content, so this PR doesn't bump up version. This PR focuses on migration from perforce prebuild instruction to github build script (in order to narrow down the scope and reduce impact as much as possible). Build script has been verified locally, and it can be verified again once we need to do AWSNativeSDK major version update.

## Testing
Tested locally

Signed-off-by: Liu <liug@amazon.com>