### PR TITLE
Move 3p AWSNativeSDK linux to github

### DIFF
--- a/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Linux
+++ b/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Linux
@@ -1,0 +1,356 @@
+#
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
+#
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+
+include(CMakeParseArguments)
+
+set(AWSNATIVESDK_PACKAGE_NAME AWSNativeSDK)
+
+set(AWS_BASE_PATH ${CMAKE_CURRENT_LIST_DIR}/${AWSNATIVESDK_PACKAGE_NAME})
+
+# Include Path
+set(AWSNATIVESDK_INCLUDE_PATH ${AWS_BASE_PATH}/include)
+
+# Determine the lib path
+if(LY_MONOLITHIC_GAME)
+    set(AWSNATIVE_SDK_LIB_PATH ${AWS_BASE_PATH}/lib/$<IF:$<CONFIG:Debug>,Debug,Release>)
+else()
+    set(AWSNATIVE_SDK_LIB_PATH ${AWS_BASE_PATH}/bin/$<IF:$<CONFIG:Debug>,Debug,Release>)
+endif()
+
+# AWS Compile Definitions
+set(AWSNATIVESDK_COMPILE_DEFINITIONS AWS_CUSTOM_MEMORY_MANAGEMENT PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
+
+set(AWSNATIVESDK_BUILD_DEPENDENCIES
+    curl # The one bundled with the aws sdk in 3rdParty doesn't use the right openssl
+)
+
+# Helper function to define individual AWSNativeSDK Libraries
+function(ly_declare_aws_library)
+
+    set(options)
+    set(oneValueArgs NAME LIB_FILE)
+    set(multiValueArgs BUILD_DEPENDENCIES)
+    
+    cmake_parse_arguments(ly_declare_aws_library "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    set(TARGET_WITH_NAMESPACE "3rdParty::${AWSNATIVESDK_PACKAGE_NAME}::${ly_declare_aws_library_NAME}")
+    if (NOT TARGET ${TARGET_WITH_NAMESPACE})
+
+        add_library(${TARGET_WITH_NAMESPACE} INTERFACE IMPORTED GLOBAL)
+
+        ly_target_include_system_directories(TARGET ${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_INCLUDE_PATH})
+
+        if (ly_declare_aws_library_LIB_FILE)
+        
+            if (LY_MONOLITHIC_GAME)
+                target_link_libraries(${TARGET_WITH_NAMESPACE} 
+                    INTERFACE
+                        ${AWSNATIVE_SDK_LIB_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}${ly_declare_aws_library_LIB_FILE}${CMAKE_STATIC_LIBRARY_SUFFIX}
+                        ${AWSNATIVESDK_BUILD_DEPENDENCIES}
+                        ${ly_declare_aws_library_BUILD_DEPENDENCIES}
+                )
+            else()
+                target_link_libraries(${TARGET_WITH_NAMESPACE} 
+                    INTERFACE
+                        ${AWSNATIVE_SDK_LIB_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}${ly_declare_aws_library_LIB_FILE}${CMAKE_SHARED_LIBRARY_SUFFIX}
+                        ${AWSNATIVESDK_BUILD_DEPENDENCIES}
+                        ${ly_declare_aws_library_BUILD_DEPENDENCIES}
+                )
+                ly_add_dependencies(${TARGET_WITH_NAMESPACE} ${AWSNATIVE_SDK_LIB_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}${ly_declare_aws_library_LIB_FILE}${CMAKE_SHARED_LIBRARY_SUFFIX}
+                ${ly_declare_aws_library_BUILD_DEPENDENCIES})
+            endif()
+                    
+        elseif (ly_declare_aws_library_BUILD_DEPENDENCIES)
+            target_link_libraries(${TARGET_WITH_NAMESPACE} 
+                INTERFACE
+                    ${ly_declare_aws_library_BUILD_DEPENDENCIES}
+            )
+        endif()
+        
+        target_link_options(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_LINK_OPTIONS})
+
+        target_compile_definitions(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_COMPILE_DEFINITIONS})
+
+    endif()
+    
+endfunction()
+
+
+#### Common ####
+if(LY_MONOLITHIC_GAME)
+    ly_declare_aws_library(
+        NAME 
+            Common
+        LIB_FILE 
+            aws-c-common
+    )       
+else()
+    ly_declare_aws_library(
+        NAME 
+            Common
+        LIB_FILE 
+            aws-c-common
+        BUILD_DEPENDENCIES
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-common.so.0unstable
+    )       
+endif()
+
+#### Checksums ####
+ly_declare_aws_library(
+    NAME 
+        Checksums
+    LIB_FILE 
+        aws-checksums
+)
+
+#### EventStream ####
+if(LY_MONOLITHIC_GAME)
+    ly_declare_aws_library(
+        NAME 
+            EventStream
+        LIB_FILE 
+            aws-c-event-stream
+        BUILD_DEPENDENCIES
+            3rdParty::AWSNativeSDK::Checksums
+    )
+else()
+    ly_declare_aws_library(
+        NAME 
+            EventStream
+        LIB_FILE 
+            aws-c-event-stream
+        BUILD_DEPENDENCIES
+            3rdParty::AWSNativeSDK::Checksums
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-event-stream.so.0unstable
+
+    )
+endif()
+
+#### Core ####
+ly_declare_aws_library(
+    NAME 
+        Core
+    LIB_FILE 
+        aws-cpp-sdk-core
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::EventStream
+        3rdParty::AWSNativeSDK::Checksums
+        3rdParty::AWSNativeSDK::Common
+)
+
+#### AccessManagement ####
+ly_declare_aws_library(
+    NAME 
+        AccessManagement
+    LIB_FILE 
+        aws-cpp-sdk-access-management
+)
+
+#### CognitoIdentity ####
+ly_declare_aws_library(
+    NAME 
+        CognitoIdentity
+    LIB_FILE 
+        aws-cpp-sdk-cognito-identity
+)
+
+#### CognitoIdp ####
+ly_declare_aws_library(
+    NAME 
+        CognitoIdp
+    LIB_FILE 
+        aws-cpp-sdk-cognito-idp
+)
+
+#### DeviceFarm ####
+ly_declare_aws_library(
+    NAME 
+        DeviceFarm
+    LIB_FILE 
+        aws-cpp-sdk-devicefarm
+)
+
+#### DynamoDB ####
+ly_declare_aws_library(
+    NAME 
+        DynamoDB
+    LIB_FILE 
+        aws-cpp-sdk-dynamodb
+)
+
+#### GameLift ####
+ly_declare_aws_library(
+    NAME 
+        GameLift
+    LIB_FILE 
+        aws-cpp-sdk-gamelift
+)
+
+#### IdentityManagement ####
+ly_declare_aws_library(
+    NAME 
+        IdentityManagement
+    LIB_FILE 
+        aws-cpp-sdk-identity-management
+)
+
+#### Kinesis ####
+ly_declare_aws_library(
+    NAME 
+        Kinesis
+    LIB_FILE 
+        aws-cpp-sdk-kinesis
+)
+
+#### Lambda ####
+ly_declare_aws_library(
+    NAME 
+        Lambda
+    LIB_FILE 
+        aws-cpp-sdk-lambda
+)
+
+#### MobileAnalytics ####
+ly_declare_aws_library(
+    NAME 
+        MobileAnalytics
+    LIB_FILE 
+        aws-cpp-sdk-mobileanalytics
+)
+
+#### Queues ####
+ly_declare_aws_library(
+    NAME 
+        Queues
+    LIB_FILE 
+        aws-cpp-sdk-queues
+)
+
+#### S3 ####
+ly_declare_aws_library(
+    NAME 
+        S3
+    LIB_FILE 
+        aws-cpp-sdk-s3
+)
+
+#### SNS ####
+ly_declare_aws_library(
+    NAME 
+        SNS
+    LIB_FILE 
+        aws-cpp-sdk-sns
+)
+
+#### SQS ####
+ly_declare_aws_library(
+    NAME 
+        SQS
+    LIB_FILE 
+        aws-cpp-sdk-sqs
+)
+
+#### STS ####
+ly_declare_aws_library(
+    NAME 
+        STS
+    LIB_FILE 
+        aws-cpp-sdk-sts
+)
+
+#### Transfer ####
+ly_declare_aws_library(
+    NAME 
+        Transfer
+    LIB_FILE 
+        aws-cpp-sdk-transfer
+)
+
+
+#########
+######### Grouping Definitions #########
+#########
+
+
+#### Dependencies ####
+ly_declare_aws_library(
+    NAME 
+        Dependencies
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::EventStream
+        3rdParty::AWSNativeSDK::Checksums
+        3rdParty::AWSNativeSDK::Common
+)
+
+#### IdentityMetrics ####
+ly_declare_aws_library(
+    NAME 
+        IdentityMetrics
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::IdentityManagement
+        3rdParty::AWSNativeSDK::MobileAnalytics
+        3rdParty::AWSNativeSDK::STS
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::Dependencies
+)
+
+#### IdentityLambda ####
+ly_declare_aws_library(
+    NAME 
+        IdentityLambda
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::IdentityManagement
+        3rdParty::AWSNativeSDK::Lambda
+        3rdParty::AWSNativeSDK::STS
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::Dependencies
+)
+
+#### GameLiftClient ####
+ly_declare_aws_library(
+    NAME 
+        GameLiftClient
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::GameLift
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::Dependencies
+)
+
+#### AWSClientAuth ####
+ly_declare_aws_library(
+    NAME 
+        AWSClientAuth
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::IdentityManagement
+        3rdParty::AWSNativeSDK::STS
+        3rdParty::AWSNativeSDK::Dependencies
+)
+
+
+#### AWSCore ####
+ly_declare_aws_library(
+    NAME 
+        AWSCore
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::DynamoDB
+        3rdParty::AWSNativeSDK::Lambda
+        3rdParty::AWSNativeSDK::S3
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::Dependencies
+)
+
+

--- a/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Linux
+++ b/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Linux
@@ -1,13 +1,7 @@
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 #
-# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-# its licensors.
-#
-# For complete copyright and license terms please see the LICENSE at the root of this
-# distribution (the "License"). All use of this software is governed by the License,
-# or, if provided, by the license below or the license accompanying this file. Do not
-# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 include(CMakeParseArguments)
 

--- a/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Linux
+++ b/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Linux
@@ -1,7 +1,9 @@
+#
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
+#
 
 include(CMakeParseArguments)
 

--- a/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Windows
+++ b/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Windows
@@ -13,24 +13,24 @@ include(CMakeParseArguments)
 
 set(AWSNATIVESDK_PACKAGE_NAME AWSNativeSDK)
 
-set(AWS_BASE_PATH $${CMAKE_CURRENT_LIST_DIR}/$${AWSNATIVESDK_PACKAGE_NAME})
+set(AWS_BASE_PATH ${CMAKE_CURRENT_LIST_DIR}/${AWSNATIVESDK_PACKAGE_NAME})
 
 # Include Path
-set(AWSNATIVESDK_INCLUDE_PATH $${AWS_BASE_PATH}/include)
+set(AWSNATIVESDK_INCLUDE_PATH ${AWS_BASE_PATH}/include)
 
 
 # Determine the lib path and possible bin path
 if (LY_MONOLITHIC_GAME)
 
     set(AWSNATIVESDK_COMPILE_DEFINITIONS AWS_CUSTOM_MEMORY_MANAGEMENT PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
-    set(AWSNATIVE_SDK_LIB_PATH $${AWS_BASE_PATH}/lib/$$<IF:$$<CONFIG:Debug>,Debug,Release>)
+    set(AWSNATIVE_SDK_LIB_PATH ${AWS_BASE_PATH}/lib/$<IF:$<CONFIG:Debug>,Debug,Release>)
     unset(AWSNATIVE_SDK_BIN_PATH)
 
 else()
 
     set(AWSNATIVESDK_COMPILE_DEFINITIONS AWS_CUSTOM_MEMORY_MANAGEMENT PLATFORM_SUPPORTS_AWS_NATIVE_SDK USE_IMPORT_EXPORT)
-    set(AWSNATIVE_SDK_LIB_PATH $${AWS_BASE_PATH}/bin/$$<IF:$$<CONFIG:Debug>,Debug,Release>)
-    set(AWSNATIVE_SDK_BIN_PATH $${AWS_BASE_PATH}/bin/$$<IF:$$<CONFIG:Debug>,Debug,Release>)
+    set(AWSNATIVE_SDK_LIB_PATH ${AWS_BASE_PATH}/bin/$<IF:$<CONFIG:Debug>,Debug,Release>)
+    set(AWSNATIVE_SDK_BIN_PATH ${AWS_BASE_PATH}/bin/$<IF:$<CONFIG:Debug>,Debug,Release>)
 
 endif()
 
@@ -41,38 +41,38 @@ function(ly_declare_aws_library)
     set(oneValueArgs NAME LIB_FILE)
     set(multiValueArgs BUILD_DEPENDENCIES)
     
-    cmake_parse_arguments(ly_declare_aws_library "$${options}" "$${oneValueArgs}" "$${multiValueArgs}" $${ARGN})
+    cmake_parse_arguments(ly_declare_aws_library "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    set(TARGET_WITH_NAMESPACE "3rdParty::$${AWSNATIVESDK_PACKAGE_NAME}::$${ly_declare_aws_library_NAME}")
-    if (NOT TARGET $${TARGET_WITH_NAMESPACE})
+    set(TARGET_WITH_NAMESPACE "3rdParty::${AWSNATIVESDK_PACKAGE_NAME}::${ly_declare_aws_library_NAME}")
+    if (NOT TARGET ${TARGET_WITH_NAMESPACE})
 
-        add_library($${TARGET_WITH_NAMESPACE} INTERFACE IMPORTED GLOBAL)
+        add_library(${TARGET_WITH_NAMESPACE} INTERFACE IMPORTED GLOBAL)
 
-        ly_target_include_system_directories(TARGET $${TARGET_WITH_NAMESPACE} INTERFACE $${AWSNATIVESDK_INCLUDE_PATH})
+        ly_target_include_system_directories(TARGET ${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_INCLUDE_PATH})
 
         if (ly_declare_aws_library_LIB_FILE)
 
-            target_link_libraries($${TARGET_WITH_NAMESPACE} 
+            target_link_libraries(${TARGET_WITH_NAMESPACE} 
                 INTERFACE
-                    $${AWSNATIVE_SDK_LIB_PATH}/$${CMAKE_STATIC_LIBRARY_PREFIX}$${ly_declare_aws_library_LIB_FILE}$${CMAKE_STATIC_LIBRARY_SUFFIX}
-                    $${ly_declare_aws_library_BUILD_DEPENDENCIES}
+                    ${AWSNATIVE_SDK_LIB_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}${ly_declare_aws_library_LIB_FILE}${CMAKE_STATIC_LIBRARY_SUFFIX}
+                    ${ly_declare_aws_library_BUILD_DEPENDENCIES}
             )
 
             if (NOT LY_MONOLITHIC_GAME)
-                ly_add_dependencies($${TARGET_WITH_NAMESPACE} $${AWSNATIVE_SDK_BIN_PATH}/$${CMAKE_SHARED_LIBRARY_PREFIX}$${ly_declare_aws_library_LIB_FILE}$${CMAKE_SHARED_LIBRARY_SUFFIX})
+                ly_add_dependencies(${TARGET_WITH_NAMESPACE} ${AWSNATIVE_SDK_BIN_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}${ly_declare_aws_library_LIB_FILE}${CMAKE_SHARED_LIBRARY_SUFFIX})
             endif()
                     
         elseif (ly_declare_aws_library_BUILD_DEPENDENCIES)
-            target_link_libraries($${TARGET_WITH_NAMESPACE} 
+            target_link_libraries(${TARGET_WITH_NAMESPACE} 
                 INTERFACE
-                    $${ly_declare_aws_library_BUILD_DEPENDENCIES}
+                    ${ly_declare_aws_library_BUILD_DEPENDENCIES}
             )
         endif()
         
-        target_link_options($${TARGET_WITH_NAMESPACE} INTERFACE $${AWSNATIVESDK_LINK_OPTIONS})
+        target_link_options(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_LINK_OPTIONS})
 
 
-        target_compile_definitions($${TARGET_WITH_NAMESPACE} INTERFACE $${AWSNATIVESDK_COMPILE_DEFINITIONS})
+        target_compile_definitions(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_COMPILE_DEFINITIONS})
 
     endif()
     

--- a/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Windows
+++ b/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Windows
@@ -1,13 +1,7 @@
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 #
-# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-# its licensors.
-#
-# For complete copyright and license terms please see the LICENSE at the root of this
-# distribution (the "License"). All use of this software is governed by the License,
-# or, if provided, by the license below or the license accompanying this file. Do not
-# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 include(CMakeParseArguments)
 

--- a/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Windows
+++ b/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Windows
@@ -1,7 +1,9 @@
+#
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
+#
 
 include(CMakeParseArguments)
 

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_linux.sh
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_linux.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+echo "Install required library: zlib1g-dev"
+sudo apt install -y zlib1g-dev || (echo "Install required library: zlib1g-dev failed" ; exit 1)
+
+echo "Install required library: libssl-dev"
+sudo apt install -y libssl-dev || (echo "Install required library: libssl-dev failed" ; exit 1)
+
+echo "Install required library: libcurl4-openssl-dev"
+sudo apt install -y libcurl4-openssl-dev || (echo "Install required library: libcurl4-openssl-dev failed" ; exit 1)
+
+src_path=temp/src
+bld_path=temp/build
+
+configure_and_build() {
+    build_type=$1
+    lib_type=$2
+    build_shared=OFF
+    if [ "$lib_type" == "Shared" ]
+    then
+        build_shared=ON
+    fi
+
+    echo "CMake Configure $build_type $lib_type"
+    CC=/usr/lib/llvm-6.0/bin/clang CXX=/usr/lib/llvm-6.0/bin/clang++ cmake -S "$src_path" -B "$bld_path/${build_type}_${lib_type}" \
+          -G "Unix Makefiles" \
+          -DTARGET_ARCH=LINUX \
+          -DCMAKE_CXX_STANDARD=17 \
+          -DENABLE_TESTING=OFF \
+          -DENABLE_RTTI=ON \
+          -DCUSTOM_MEMORY_MANAGEMENT=ON \
+          -DBUILD_ONLY="access-management;cognito-identity;cognito-idp;core;devicefarm;dynamodb;gamelift;identity-management;kinesis;lambda;mobileanalytics;queues;s3;sns;sqs;sts;transfer" \
+          -DBUILD_SHARED_LIBS=$build_shared \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_INSTALL_BINDIR="bin/$build_type" \
+          -DCMAKE_INSTALL_LIBDIR="lib/$build_type" || (echo "CMake Configure $build_type $lib_type failed" ; exit 1)
+
+    echo "CMake Build $build_type $lib_type to $bld_path/${build_type}_${lib_type}"
+    cmake --build "$bld_path/${build_type}_${lib_type}" --config $build_type -j 12 || (echo "CMake Build $build_type $lib_type to $bld_path/${build_type}_${lib_type} failed" ; exit 1)
+}
+
+# Debug Shared
+configure_and_build Debug Shared || exit 1
+
+# Debug Static
+configure_and_build Debug Static || exit 1
+
+# Release Shared
+configure_and_build Release Shared || exit 1
+
+# Release Static
+configure_and_build Release Static || exit 1
+
+echo "Custom Build for AWSNativeSDK finished successfully"
+exit 0

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_linux.sh
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_linux.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-
+#
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-
+#
 
 if ! dpkg-query -W -f'${Status}' "zlib1g-dev" 2>/dev/null | grep -q "ok installed"
 then

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_linux.sh
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_linux.sh
@@ -46,7 +46,7 @@ configure_and_build() {
           -DCUSTOM_MEMORY_MANAGEMENT=ON \
           -DBUILD_ONLY="access-management;cognito-identity;cognito-idp;core;devicefarm;dynamodb;gamelift;identity-management;kinesis;lambda;mobileanalytics;queues;s3;sns;sqs;sts;transfer" \
           -DBUILD_SHARED_LIBS=$build_shared \
-          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_BUILD_TYPE=$build_type \
           -DCMAKE_INSTALL_BINDIR="bin/$build_type" \
           -DCMAKE_INSTALL_LIBDIR="lib/$build_type" || (echo "CMake Configure $build_type $lib_type failed" ; exit 1)
 

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_linux.sh
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_linux.sh
@@ -5,14 +5,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-echo "Install required library: zlib1g-dev"
-sudo apt install -y zlib1g-dev || (echo "Install required library: zlib1g-dev failed" ; exit 1)
 
-echo "Install required library: libssl-dev"
-sudo apt install -y libssl-dev || (echo "Install required library: libssl-dev failed" ; exit 1)
+if ! dpkg-query -W -f'${Status}' "zlib1g-dev" 2>/dev/null | grep -q "ok installed"
+then
+    echo "Required package zlib1g-dev is not installed"
+    exit 1 
+fi
 
-echo "Install required library: libcurl4-openssl-dev"
-sudo apt install -y libcurl4-openssl-dev || (echo "Install required library: libcurl4-openssl-dev failed" ; exit 1)
+if ! dpkg-query -W -f'${Status}' "libssl-dev" 2>/dev/null | grep -q "ok installed"
+then
+    echo "Required package libssl-dev is not installed"
+    exit 1
+fi
+
+if ! dpkg-query -W -f'${Status}' "libcurl4-openssl-dev" 2>/dev/null | grep -q "ok installed"
+then
+    echo "Required package libcurl4-openssl-dev is not installed"
+    exit 1
+fi
 
 src_path=temp/src
 bld_path=temp/build

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_windows.cmd
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_windows.cmd
@@ -47,6 +47,7 @@ ECHO "CMake Configure %BUILD_TYPE% %LIB_TYPE%"
 call cmake -S %SRC_PATH% -B %BLD_PATH%\%BUILD_TYPE%_%LIB_TYPE% ^
            -G "Visual Studio 16 2019" ^
            -A x64 ^
+           -DTARGET_ARCH=WINDOWS ^
            -DCPP_STANDARD=17 ^
            -DBUILD_ONLY="access-management;cognito-identity;cognito-idp;core;devicefarm;dynamodb;gamelift;identity-management;kinesis;lambda;mobileanalytics;queues;s3;sns;sqs;sts;transfer" ^
            -DENABLE_TESTING=OFF ^

--- a/package-system/AWSNativeSDK/build_config.json
+++ b/package-system/AWSNativeSDK/build_config.json
@@ -12,12 +12,24 @@
    "Platforms":{
       "Windows":{
          "Windows":{
-            "cmake_find_template":"FindAWSNativeSDK.cmake.Windows.template",
+            "cmake_find_source":"FindAWSNativeSDK.cmake.Windows",
             "custom_build_cmd": [
                "build_AWSNativeSDK_windows.cmd"
             ],
             "custom_install_cmd": [
                "install_AWSNativeSDK_windows.cmd"
+            ]
+         }
+      },
+      "Linux":{
+         "Linux":{
+            "package_version":"1.7.167-rev5",
+            "cmake_find_source":"FindAWSNativeSDK.cmake.Linux",
+            "custom_build_cmd": [
+               "./build_AWSNativeSDK_linux.sh"
+            ],
+            "custom_install_cmd": [
+               "./install_AWSNativeSDK_linux.sh"
             ]
          }
       }

--- a/package-system/AWSNativeSDK/build_config.json
+++ b/package-system/AWSNativeSDK/build_config.json
@@ -12,6 +12,7 @@
    "Platforms":{
       "Windows":{
          "Windows":{
+            "package_version":"1.7.167-rev4",
             "cmake_find_source":"FindAWSNativeSDK.cmake.Windows",
             "custom_build_cmd": [
                "build_AWSNativeSDK_windows.cmd"
@@ -23,7 +24,7 @@
       },
       "Linux":{
          "Linux":{
-            "package_version":"1.7.167-rev5",
+            "package_version":"1.7.167-rev6",
             "cmake_find_source":"FindAWSNativeSDK.cmake.Linux",
             "custom_build_cmd": [
                "./build_AWSNativeSDK_linux.sh"

--- a/package-system/AWSNativeSDK/install_AWSNativeSDK_linux.sh
+++ b/package-system/AWSNativeSDK/install_AWSNativeSDK_linux.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+src_path=temp/src
+bld_path=temp/build
+inst_path=temp/install
+out_bin_path=$TARGET_INSTALL_ROOT/bin
+mkdir -p $out_bin_path/Debug
+mkdir -p $out_bin_path/Release
+out_include_path=$TARGET_INSTALL_ROOT/include
+mkdir -p $out_include_path
+
+out_lib_path=$TARGET_INSTALL_ROOT/lib
+mkdir -p $out_lib_path/Debug
+mkdir -p $out_lib_path/Release
+
+copy_shared_and_static_libs() {
+    local bld_type=$1
+    echo "Copying shared .so to $out_bin_path/$bld_type"
+    cp -f "$inst_path/lib/$bld_type/"*".so"* $out_bin_path/$bld_type/ || (echo "Copying shared .so to $out_bin_path/$bld_type failed" ; exit 1)
+
+    echo "Copying 3rdParty shared .so to $out_bin_path/$bld_type"
+    cp -f "$bld_path/${bld_type}_Shared/.deps/install/lib/"*".so"* $out_bin_path/$bld_type/ || (echo "Copying 3rdParty shared .so to $out_bin_path/$bld_type failed" ; exit 1)
+
+    echo "Copying static .a to $out_lib_path/$bld_type"
+    cp -f "$inst_path/lib/$bld_type/"*".a" $out_lib_path/$bld_type/ || (echo "Copying static .a to $out_lib_path/$bld_type failed" ; exit 1)
+
+    echo "Copying 3rdParty static .a to $out_lib_path/$bld_type"
+    cp -f "$bld_path/${bld_type}_Static/.deps/install/lib/"*".a" $out_lib_path/$bld_type/ || (echo "Copying 3rdParty static .a to $out_lib_path/$bld_type failed" ; exit 1)
+}
+
+# Debug
+echo "CMake Install Debug Shared to $inst_path"
+cmake --install $bld_path/Debug_Shared --prefix $inst_path --config Debug || (echo "CMake Install Debug Shared to $inst_path failed" ; exit 1)
+
+echo "CMake Install Debug Static to $inst_path"
+cmake --install $bld_path/Debug_Static --prefix $inst_path --config Debug || (echo "CMake Install Debug Static to $inst_path failed" ; exit 1)
+
+copy_shared_and_static_libs Debug || exit 1
+
+# Release
+echo "CMake Install Release Shared to $inst_path"
+cmake --install $bld_path/Release_Shared --prefix $inst_path --config Release || (echo "CMake Install Release Shared to $inst_path failed" ; exit 1)
+
+echo "CMake Install Release Static to $inst_path"
+cmake --install $bld_path/Release_Static --prefix $inst_path --config Release || (echo "CMake Install Release Static to $inst_path failed" ; exit 1)
+
+copy_shared_and_static_libs Release || exit 1
+
+echo "Copying include headers to $out_include_path"
+cp -f -R "$inst_path/include/"* $out_include_path/ || (echo "Copying include headers to $out_include_path failed" ; exit 1)
+
+echo "Copying LICENSE.txt to $TARGET_INSTALL_ROOT"
+cp -f $src_path/LICENSE.txt $TARGET_INSTALL_ROOT/ || (echo "Copying LICENSE.txt to $TARGET_INSTALL_ROOT failed" ; exit 1)
+
+echo "Custom Install for AWSNativeSDK finished successfully"
+exit 0

--- a/package-system/AWSNativeSDK/install_AWSNativeSDK_linux.sh
+++ b/package-system/AWSNativeSDK/install_AWSNativeSDK_linux.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
-
+#
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
+#
 
 src_path=temp/src
 bld_path=temp/build
 inst_path=temp/install
+
 out_bin_path=$TARGET_INSTALL_ROOT/bin
 mkdir -p $out_bin_path/Debug
 mkdir -p $out_bin_path/Release
+
 out_include_path=$TARGET_INSTALL_ROOT/include
 mkdir -p $out_include_path
 

--- a/package_build_list_host_linux.json
+++ b/package_build_list_host_linux.json
@@ -4,7 +4,7 @@
     "comment3" : "build_from_folder is package name --> folder containing built image of package",
     "comment4" : "Note:  Build from source occurs before build_from_folder",
     "build_from_source": {
-        "AWSNativeSDK-1.7.167-rev5-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Linux --package-root ../../package-system --clean",
+        "AWSNativeSDK-1.7.167-rev6-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Linux --package-root ../../package-system --clean",
         "Lua-5.3.5-rev5-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Lua --platform-name Linux --package-root ../../package-system --clean",
         "AwsIotDeviceSdkCpp-1.12.2-rev1-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AwsIotDeviceSdkCpp --platform-name Linux --package-root ../../package-system --clean",
         "etc2comp-9cd0f9cae0-rev1-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/etc2comp --platform-name Linux --package-root ../../package-system --clean",
@@ -29,9 +29,9 @@
         "mikkelsen-1.0.0.4-linux": "package-system/mikkelsen/build_package_image.py",
         "zlib-1.2.11-rev1-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Linux --package-root ../../package-system --clean"
     },
-    "build_from_folder": {
+    "build_from_folder" : {
         "AWSGameLiftServerSDK-3.4.1-rev1-linux": "package-system/AWSGameLiftServerSDK/linux",
-        "AWSNativeSDK-1.7.167-rev5-linux": "package-system/AWSNativeSDK-linux",
+        "AWSNativeSDK-1.7.167-rev6-linux": "package-system/AWSNativeSDK-linux",
         "Lua-5.3.5-rev5-linux": "package-system/Lua-linux",
         "AwsIotDeviceSdkCpp-1.12.2-rev1-linux": "package-system/AwsIotDeviceSdkCpp-linux",
         "etc2comp-9cd0f9cae0-rev1-linux": "package-system/etc2comp-linux",

--- a/package_build_list_host_windows.json
+++ b/package_build_list_host_windows.json
@@ -4,7 +4,7 @@
     "comment3" : "build_from_folder is package name --> folder containing built image of package",
     "comment4" : "Note:  Build from source occurs before build_from_folder",
     "build_from_source" : {
-        "AWSNativeSDK-1.7.167-rev3-windows" : "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Windows --package-root ../../package-system --clean",
+        "AWSNativeSDK-1.7.167-rev4-windows" : "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Windows --package-root ../../package-system --clean",
         "AWSNativeSDK-1.7.167-rev6-android" : "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Android --package-root ../../package-system --clean",
         "Blast-v1.1.7_rc2-9-geb169fe-rev2-windows": "package-system/Blast/build_package_image.py --platform-name windows",
         "Crashpad-0.8.0-rev1-windows" : "package-system/Crashpad/build_package_image.py",
@@ -45,7 +45,7 @@
       },
   "build_from_folder": {
     "AWSGameLiftServerSDK-3.4.1-rev1-windows" : "package-system/AWSGameLiftServerSDK/windows",
-    "AWSNativeSDK-1.7.167-rev3-windows": "package-system/AWSNativeSDK-windows",
+    "AWSNativeSDK-1.7.167-rev4-windows": "package-system/AWSNativeSDK-windows",
     "AWSNativeSDK-1.7.167-rev6-android": "package-system/AWSNativeSDK-android",
     "Blast-v1.1.7_rc2-9-geb169fe-rev2-windows": "package-system/Blast-windows",
     "Crashpad-0.8.0-rev1-windows" : "package-system/Crashpad-windows",


### PR DESCRIPTION
## Details
1. Move existing FindAWSNativeSDK to github
2. Add custom build and install script for linux

Note: Bump the windows and linux package version as the FindAWSNativeSDK need a copyright update

## Testing
Tested locally
Get the same failures as nightly build, the failures are caused by dev branch.
Windows:
https://jenkins-pipeline.agscollab.com/blue/organizations/jenkins/O3DE-LY-FORK/detail/LYN-5564/4/pipeline

Linux:
https://jenkins-pipeline.agscollab.com/blue/organizations/jenkins/O3DE-LY-FORK/detail/LYN-5564/5/pipeline

Signed-off-by: liug <liug@uf5437f6faf8e57.ant.amazon.com>