### PR TITLE
Move 3p AWSNativeSDK mac to github

### DIFF
--- a/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Mac
+++ b/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Mac
@@ -1,7 +1,9 @@
+#
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
+#
 
 include(CMakeParseArguments)
 

--- a/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Mac
+++ b/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Mac
@@ -1,0 +1,362 @@
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+include(CMakeParseArguments)
+
+set(AWSNATIVESDK_PACKAGE_NAME AWSNativeSDK)
+
+set(AWS_BASE_PATH ${CMAKE_CURRENT_LIST_DIR}/${AWSNATIVESDK_PACKAGE_NAME})
+
+# Include Path
+set(AWSNATIVESDK_INCLUDE_PATH ${AWS_BASE_PATH}/include)
+
+# Determine the lib path
+if(LY_MONOLITHIC_GAME)
+    set(AWSNATIVE_SDK_LIB_PATH ${AWS_BASE_PATH}/lib/$<IF:$<CONFIG:Debug>,Debug,Release>)
+else()
+    set(AWSNATIVE_SDK_LIB_PATH ${AWS_BASE_PATH}/bin/$<IF:$<CONFIG:Debug>,Debug,Release>)
+endif()
+
+# AWS Compile Definitions
+set(AWSNATIVESDK_COMPILE_DEFINITIONS AWS_CUSTOM_MEMORY_MANAGEMENT PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
+
+set(AWSNATIVESDK_BUILD_DEPENDENCIES
+    curl # The one bundled with the aws sdk in 3rdParty doesn't use the right openssl
+)
+
+# Helper function to define individual AWSNativeSDK Libraries
+function(ly_declare_aws_library)
+
+    set(options)
+    set(oneValueArgs NAME LIB_FILE)
+    set(multiValueArgs BUILD_DEPENDENCIES RUNTIME_DEPENDENCIES)
+    
+    cmake_parse_arguments(ly_declare_aws_library "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    set(TARGET_WITH_NAMESPACE "3rdParty::${AWSNATIVESDK_PACKAGE_NAME}::${ly_declare_aws_library_NAME}")
+    if (NOT TARGET ${TARGET_WITH_NAMESPACE})
+
+        add_library(${TARGET_WITH_NAMESPACE} INTERFACE IMPORTED GLOBAL)
+
+        ly_target_include_system_directories(TARGET ${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_INCLUDE_PATH})
+
+        if (ly_declare_aws_library_LIB_FILE)
+        
+            if (LY_MONOLITHIC_GAME)
+                target_link_libraries(${TARGET_WITH_NAMESPACE} 
+                    INTERFACE
+                        ${AWSNATIVE_SDK_LIB_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}${ly_declare_aws_library_LIB_FILE}${CMAKE_STATIC_LIBRARY_SUFFIX}
+                        ${AWSNATIVESDK_BUILD_DEPENDENCIES}
+                        ${ly_declare_aws_library_BUILD_DEPENDENCIES}
+                )
+            else()
+                target_link_libraries(${TARGET_WITH_NAMESPACE} 
+                    INTERFACE
+                        ${AWSNATIVE_SDK_LIB_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}${ly_declare_aws_library_LIB_FILE}${CMAKE_SHARED_LIBRARY_SUFFIX}
+                        ${AWSNATIVESDK_BUILD_DEPENDENCIES}
+                        ${ly_declare_aws_library_BUILD_DEPENDENCIES}
+                )
+                ly_add_dependencies(${TARGET_WITH_NAMESPACE} ${AWSNATIVE_SDK_LIB_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}${ly_declare_aws_library_LIB_FILE}${CMAKE_SHARED_LIBRARY_SUFFIX})
+
+                # Add any runtime dependencies if exist
+                if (ly_declare_aws_library_RUNTIME_DEPENDENCIES)
+                    ly_add_dependencies(${TARGET_WITH_NAMESPACE} ${ly_declare_aws_library_RUNTIME_DEPENDENCIES})
+                endif()
+            endif()
+                    
+        elseif (ly_declare_aws_library_BUILD_DEPENDENCIES)
+            target_link_libraries(${TARGET_WITH_NAMESPACE} 
+                INTERFACE
+                    ${ly_declare_aws_library_BUILD_DEPENDENCIES}
+            )
+
+        elseif (ly_declare_aws_library_RUNTIME_DEPENDENCIES)
+            ly_add_dependencies(${TARGET_WITH_NAMESPACE} ${ly_declare_aws_library_RUNTIME_DEPENDENCIES})
+        endif()
+        
+        target_link_options(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_LINK_OPTIONS})
+
+
+        target_compile_definitions(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_COMPILE_DEFINITIONS})
+
+    endif()
+    
+endfunction()
+
+
+#### Common ####
+if(LY_MONOLITHIC_GAME)
+    ly_declare_aws_library(
+        NAME 
+            Common
+        LIB_FILE 
+            aws-c-common
+    )       
+else()
+    ly_declare_aws_library(
+        NAME 
+            Common
+        LIB_FILE 
+            aws-c-common
+        BUILD_DEPENDENCIES
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-common${CMAKE_SHARED_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-common.0unstable${CMAKE_SHARED_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-common.1.0.0${CMAKE_SHARED_LIBRARY_SUFFIX}
+        RUNTIME_DEPENDENCIES
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-common.0unstable${CMAKE_SHARED_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-common.1.0.0${CMAKE_SHARED_LIBRARY_SUFFIX}
+    )       
+endif()
+
+#### Checksums ####
+ly_declare_aws_library(
+    NAME 
+        Checksums
+    LIB_FILE 
+        aws-checksums
+)
+
+#### EventStream ####
+if(LY_MONOLITHIC_GAME)
+    ly_declare_aws_library(
+        NAME 
+            EventStream
+        LIB_FILE 
+            aws-c-event-stream
+        BUILD_DEPENDENCIES 
+            3rdParty::AWSNativeSDK::Checksums
+    )
+else()
+    ly_declare_aws_library(
+        NAME 
+            EventStream
+        LIB_FILE 
+            aws-c-event-stream
+        BUILD_DEPENDENCIES
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-event-stream${CMAKE_SHARED_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-event-stream.0unstable${CMAKE_SHARED_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-event-stream.1.0.0${CMAKE_SHARED_LIBRARY_SUFFIX}
+            3rdParty::AWSNativeSDK::Checksums
+    )
+endif()
+
+#### Core ####
+ly_declare_aws_library(
+    NAME 
+        Core
+    LIB_FILE 
+        aws-cpp-sdk-core
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Common
+        3rdParty::AWSNativeSDK::EventStream
+)
+
+#### AccessManagement ####
+ly_declare_aws_library(
+    NAME 
+        AccessManagement
+    LIB_FILE 
+        aws-cpp-sdk-access-management
+)
+
+#### CognitoIdentity ####
+ly_declare_aws_library(
+    NAME 
+        CognitoIdentity
+    LIB_FILE 
+        aws-cpp-sdk-cognito-identity
+)
+
+#### CognitoIdp ####
+ly_declare_aws_library(
+    NAME 
+        CognitoIdp
+    LIB_FILE 
+        aws-cpp-sdk-cognito-idp
+)
+
+#### DeviceFarm ####
+ly_declare_aws_library(
+    NAME 
+        DeviceFarm
+    LIB_FILE 
+        aws-cpp-sdk-devicefarm
+)
+
+#### DynamoDB ####
+ly_declare_aws_library(
+    NAME 
+        DynamoDB
+    LIB_FILE 
+        aws-cpp-sdk-dynamodb
+)
+
+#### GameLift ####
+ly_declare_aws_library(
+    NAME 
+        GameLift
+    LIB_FILE 
+        aws-cpp-sdk-gamelift
+)
+
+#### IdentityManagement ####
+ly_declare_aws_library(
+    NAME 
+        IdentityManagement
+    LIB_FILE 
+        aws-cpp-sdk-identity-management
+)
+
+#### Kinesis ####
+ly_declare_aws_library(
+    NAME 
+        Kinesis
+    LIB_FILE 
+        aws-cpp-sdk-kinesis
+)
+
+#### Lambda ####
+ly_declare_aws_library(
+    NAME 
+        Lambda
+    LIB_FILE 
+        aws-cpp-sdk-lambda
+)
+
+#### MobileAnalytics ####
+ly_declare_aws_library(
+    NAME 
+        MobileAnalytics
+    LIB_FILE 
+        aws-cpp-sdk-mobileanalytics
+)
+
+#### Queues ####
+ly_declare_aws_library(
+    NAME 
+        Queues
+    LIB_FILE 
+        aws-cpp-sdk-queues
+)
+
+#### S3 ####
+ly_declare_aws_library(
+    NAME 
+        S3
+    LIB_FILE 
+        aws-cpp-sdk-s3
+)
+
+#### SNS ####
+ly_declare_aws_library(
+    NAME 
+        SNS
+    LIB_FILE 
+        aws-cpp-sdk-sns
+)
+
+#### SQS ####
+ly_declare_aws_library(
+    NAME 
+        SQS
+    LIB_FILE 
+        aws-cpp-sdk-sqs
+)
+
+#### STS ####
+ly_declare_aws_library(
+    NAME 
+        STS
+    LIB_FILE 
+        aws-cpp-sdk-sts
+)
+
+#### Transfer ####
+ly_declare_aws_library(
+    NAME 
+        Transfer
+    LIB_FILE 
+        aws-cpp-sdk-transfer
+)
+
+
+#########
+######### Grouping Definitions #########
+#########
+
+
+#### Dependencies ####
+ly_declare_aws_library(
+    NAME 
+        Dependencies
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Checksums
+        3rdParty::AWSNativeSDK::Common
+        3rdParty::AWSNativeSDK::EventStream
+)
+
+#### IdentityMetrics ####
+ly_declare_aws_library(
+    NAME 
+        IdentityMetrics
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Dependencies
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::IdentityManagement
+        3rdParty::AWSNativeSDK::STS
+        3rdParty::AWSNativeSDK::MobileAnalytics
+)
+
+#### IdentityLambda ####
+ly_declare_aws_library(
+    NAME 
+        IdentityLambda
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Dependencies
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::IdentityManagement
+        3rdParty::AWSNativeSDK::Lambda
+        3rdParty::AWSNativeSDK::STS
+)
+
+#### GameLiftClient ####
+ly_declare_aws_library(
+    NAME 
+        GameLiftClient
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::GameLift
+        3rdParty::AWSNativeSDK::Dependencies
+)
+
+#### AWSClientAuth ####
+ly_declare_aws_library(
+    NAME 
+        AWSClientAuth
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Dependencies
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::STS
+        3rdParty::AWSNativeSDK::IdentityManagement
+)
+
+
+#### AWSCore ####
+ly_declare_aws_library(
+    NAME 
+        AWSCore
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Dependencies
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::DynamoDB
+        3rdParty::AWSNativeSDK::Lambda
+        3rdParty::AWSNativeSDK::S3
+)
+

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_mac.sh
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_mac.sh
@@ -27,7 +27,7 @@ configure_and_build() {
           -DCUSTOM_MEMORY_MANAGEMENT=ON \
           -DBUILD_ONLY="access-management;cognito-identity;cognito-idp;core;devicefarm;dynamodb;gamelift;identity-management;kinesis;lambda;mobileanalytics;queues;s3;sns;sqs;sts;transfer" \
           -DBUILD_SHARED_LIBS=$build_shared \
-          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_BUILD_TYPE=$build_type \
           -DCMAKE_INSTALL_BINDIR="bin/$build_type" \
           -DCMAKE_INSTALL_LIBDIR="lib/$build_type" || (echo "CMake Configure $build_type $lib_type failed" ; exit 1)
 

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_mac.sh
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_mac.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+src_path=temp/src
+bld_path=temp/build
+
+configure_and_build() {
+    build_type=$1
+    lib_type=$2
+    build_shared=OFF
+    if [ "$lib_type" == "Shared" ]
+    then
+        build_shared=ON
+    fi
+
+    echo "CMake Configure $build_type $lib_type"
+    CXXFLAGS=-Wno-deprecated-declarations cmake -S "$src_path" -B "$bld_path/${build_type}_${lib_type}" \
+          -G "Xcode" \
+          -DCMAKE_OSX_ARCHITECTURES="x86_64" \
+          -DCMAKE_CXX_STANDARD=17 \
+          -DENABLE_TESTING=OFF \
+          -DENABLE_RTTI=ON \
+          -DCUSTOM_MEMORY_MANAGEMENT=ON \
+          -DBUILD_ONLY="access-management;cognito-identity;cognito-idp;core;devicefarm;dynamodb;gamelift;identity-management;kinesis;lambda;mobileanalytics;queues;s3;sns;sqs;sts;transfer" \
+          -DBUILD_SHARED_LIBS=$build_shared \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_INSTALL_BINDIR="bin/$build_type" \
+          -DCMAKE_INSTALL_LIBDIR="lib/$build_type" || (echo "CMake Configure $build_type $lib_type failed" ; exit 1)
+
+    echo "CMake Build $build_type $lib_type to $bld_path/${build_type}_${lib_type}"
+    cmake --build "$bld_path/${build_type}_${lib_type}" --config $build_type -j 12 || (echo "CMake Build $build_type $lib_type to $bld_path/${build_type}_${lib_type} failed" ; exit 1)
+}
+
+# Debug Shared
+configure_and_build Debug Shared || exit 1
+
+# Debug Static
+configure_and_build Debug Static || exit 1
+
+# Release Shared
+configure_and_build Release Shared || exit 1
+
+# Release Static
+configure_and_build Release Static || exit 1
+
+echo "Custom Build for AWSNativeSDK finished successfully"
+exit 0

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_mac.sh
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_mac.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-
+#
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
+#
 
 src_path=temp/src
 bld_path=temp/build
@@ -20,6 +21,7 @@ configure_and_build() {
     echo "CMake Configure $build_type $lib_type"
     CXXFLAGS=-Wno-deprecated-declarations cmake -S "$src_path" -B "$bld_path/${build_type}_${lib_type}" \
           -G "Xcode" \
+          -DTARGET_ARCH=APPLE \
           -DCMAKE_OSX_ARCHITECTURES="x86_64" \
           -DCMAKE_CXX_STANDARD=17 \
           -DENABLE_TESTING=OFF \

--- a/package-system/AWSNativeSDK/build_config.json
+++ b/package-system/AWSNativeSDK/build_config.json
@@ -22,6 +22,18 @@
             ]
          }
       },
+      "Darwin":{
+         "Mac":{
+            "package_version":"1.7.167-rev4",
+            "cmake_find_source":"FindAWSNativeSDK.cmake.Mac",
+            "custom_build_cmd": [
+               "./build_AWSNativeSDK_mac.sh"
+            ],
+            "custom_install_cmd": [
+               "./install_AWSNativeSDK_mac.sh"
+            ]
+         }
+      },
       "Linux":{
          "Linux":{
             "package_version":"1.7.167-rev6",

--- a/package-system/AWSNativeSDK/build_config.json
+++ b/package-system/AWSNativeSDK/build_config.json
@@ -24,7 +24,7 @@
       },
       "Darwin":{
          "Mac":{
-            "package_version":"1.7.167-rev4",
+            "package_version":"1.7.167-rev5",
             "cmake_find_source":"FindAWSNativeSDK.cmake.Mac",
             "custom_build_cmd": [
                "./build_AWSNativeSDK_mac.sh"

--- a/package-system/AWSNativeSDK/install_AWSNativeSDK_mac.sh
+++ b/package-system/AWSNativeSDK/install_AWSNativeSDK_mac.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-
+#
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
+#
 
 src_path=temp/src
 bld_path=temp/build

--- a/package-system/AWSNativeSDK/install_AWSNativeSDK_mac.sh
+++ b/package-system/AWSNativeSDK/install_AWSNativeSDK_mac.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+src_path=temp/src
+bld_path=temp/build
+inst_path=temp/install
+
+out_bin_path=$TARGET_INSTALL_ROOT/bin
+mkdir -p $out_bin_path/Debug
+mkdir -p $out_bin_path/Release
+
+out_include_path=$TARGET_INSTALL_ROOT/include
+mkdir -p $out_include_path
+
+out_lib_path=$TARGET_INSTALL_ROOT/lib
+mkdir -p $out_lib_path/Debug
+mkdir -p $out_lib_path/Release
+
+copy_shared_and_static_libs() {
+    local bld_type=$1
+    echo "Copying shared .dylib to $out_bin_path/$bld_type"
+    cp -f "$inst_path/lib/$bld_type/"*".dylib" $out_bin_path/$bld_type/ || (echo "Copying shared .dylib to $out_bin_path/$bld_type failed" ; exit 1)
+
+    echo "Copying 3rdParty shared .dylib to $out_bin_path/$bld_type"
+    cp -f "$bld_path/${bld_type}_Shared/.deps/install/lib/"*".dylib" $out_bin_path/$bld_type/ || (echo "Copying 3rdParty shared .dylib to $out_bin_path/$bld_type failed" ; exit 1)
+
+    echo "Copying static .a to $out_lib_path/$bld_type"
+    cp -f "$inst_path/lib/$bld_type/"*".a" $out_lib_path/$bld_type/ || (echo "Copying static .a to $out_lib_path/$bld_type failed" ; exit 1)
+
+    echo "Copying 3rdParty static .a to $out_lib_path/$bld_type"
+    cp -f "$bld_path/${bld_type}_Static/.deps/install/lib/"*".a" $out_lib_path/$bld_type/ || (echo "Copying 3rdParty static .a to $out_lib_path/$bld_type failed" ; exit 1)
+}
+
+# Debug
+echo "CMake Install Debug Shared to $inst_path"
+cmake --install $bld_path/Debug_Shared --prefix $inst_path --config Debug || (echo "CMake Install Debug Shared to $inst_path failed" ; exit 1)
+
+echo "CMake Install Debug Static to $inst_path"
+cmake --install $bld_path/Debug_Static --prefix $inst_path --config Debug || (echo "CMake Install Debug Static to $inst_path failed" ; exit 1)
+
+copy_shared_and_static_libs Debug || exit 1
+
+# Release
+echo "CMake Install Release Shared to $inst_path"
+cmake --install $bld_path/Release_Shared --prefix $inst_path --config Release || (echo "CMake Install Release Shared to $inst_path failed" ; exit 1)
+
+echo "CMake Install Release Static to $inst_path"
+cmake --install $bld_path/Release_Static --prefix $inst_path --config Release || (echo "CMake Install Release Static to $inst_path failed" ; exit 1)
+
+copy_shared_and_static_libs Release || exit 1
+
+echo "Copying include headers to $out_include_path"
+cp -f -R "$inst_path/include/"* $out_include_path/ || (echo "Copying include headers to $out_include_path failed" ; exit 1)
+
+echo "Copying LICENSE.txt to $TARGET_INSTALL_ROOT"
+cp -f $src_path/LICENSE.txt $TARGET_INSTALL_ROOT/ || (echo "Copying LICENSE.txt to $TARGET_INSTALL_ROOT failed" ; exit 1)
+
+echo "Custom Install for AWSNativeSDK finished successfully"
+exit 0

--- a/package_build_list_host_darwin.json
+++ b/package_build_list_host_darwin.json
@@ -4,7 +4,7 @@
     "comment3" : "build_from_folder is package name --> folder containing built image of package",
     "comment4" : "Note:  Build from source occurs before build_from_folder",
     "build_from_source": {
-        "AWSNativeSDK-1.7.167-rev4-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Mac --package-root ../../package-system --clean",
+        "AWSNativeSDK-1.7.167-rev5-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Mac --package-root ../../package-system --clean",
         "AWSNativeSDK-1.7.167-rev3-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name iOS --package-root ../../package-system --clean",
         "Lua-5.3.5-rev6-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Lua --platform-name Mac --package-root ../../package-system --clean",
         "Lua-5.3.5-rev5-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Lua --platform-name iOS --package-root ../../package-system --clean",
@@ -42,7 +42,7 @@
         "zlib-1.2.11-rev1-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name iOS --package-root ../../package-system --clean"
     },
     "build_from_folder": {
-        "AWSNativeSDK-1.7.167-rev4-mac": "package-system/AWSNativeSDK-mac",
+        "AWSNativeSDK-1.7.167-rev5-mac": "package-system/AWSNativeSDK-mac",
         "AWSNativeSDK-1.7.167-rev3-ios": "package-system/AWSNativeSDK-ios",
         "Lua-5.3.5-rev6-mac": "package-system/Lua-mac",
         "Lua-5.3.5-rev5-ios": "package-system/Lua-ios",

--- a/package_build_list_host_darwin.json
+++ b/package_build_list_host_darwin.json
@@ -4,7 +4,7 @@
     "comment3" : "build_from_folder is package name --> folder containing built image of package",
     "comment4" : "Note:  Build from source occurs before build_from_folder",
     "build_from_source": {
-        "AWSNativeSDK-1.7.167-rev3-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Mac --package-root ../../package-system --clean",
+        "AWSNativeSDK-1.7.167-rev4-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Mac --package-root ../../package-system --clean",
         "AWSNativeSDK-1.7.167-rev3-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name iOS --package-root ../../package-system --clean",
         "Lua-5.3.5-rev6-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Lua --platform-name Mac --package-root ../../package-system --clean",
         "Lua-5.3.5-rev5-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Lua --platform-name iOS --package-root ../../package-system --clean",
@@ -42,7 +42,7 @@
         "zlib-1.2.11-rev1-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name iOS --package-root ../../package-system --clean"
     },
     "build_from_folder": {
-        "AWSNativeSDK-1.7.167-rev3-mac": "package-system/AWSNativeSDK-mac",
+        "AWSNativeSDK-1.7.167-rev4-mac": "package-system/AWSNativeSDK-mac",
         "AWSNativeSDK-1.7.167-rev3-ios": "package-system/AWSNativeSDK-ios",
         "Lua-5.3.5-rev6-mac": "package-system/Lua-mac",
         "Lua-5.3.5-rev5-ios": "package-system/Lua-ios",


### PR DESCRIPTION
## Details
1. Move existing FindAWSNativeSDK to github
2. Add custom build and install script for mac

Note: Bump the windows and linux package version as the FindAWSNativeSDK need a copyright update

## Testing
Tested locally
Get the same failures as nightly build, the failures are caused by dev branch.
Mac:
https://jenkins-pipeline.agscollab.com/blue/organizations/jenkins/O3DE-LY-FORK/detail/LYN-5564/4/pipeline

Signed-off-by: liug <liug@amazon.com>