### PR TITLE
Update Blast build scripts to include PhysXFoundation_64.dll

### DIFF
--- a/package-system/Blast/FindBlast.cmake
+++ b/package-system/Blast/FindBlast.cmake
@@ -58,6 +58,15 @@ if(${PAL_PLATFORM_NAME} STREQUAL "Windows")
         ${_DLLS_DIR}/vc15win64-cmake/$<LOWER_CASE:$<CONFIG>>/NvBlastGlobals_x64.dll
         ${_DLLS_DIR}/vc15win64-cmake/$<LOWER_CASE:$<CONFIG>>/NvBlastTk_x64.dll
     )
+    
+    # When building O3DE monolithicaly the library PhysXFoundation_64.dll won't be present since
+    # PhysX SDK uses a static version of it. Because of this Blast will provide the dll in this case, which
+    # is needed by its extended tools libraries NvBlastExtPhysX_x64.dll and NvBlastExtPxSerialization_x64.dll.
+    if(LY_MONOLITHIC_GAME)
+        list(APPEND ${MY_NAME}_RUNTIME_DEPENDENCIES
+            ${_DLLS_DIR}/vc15win64-cmake/$<LOWER_CASE:$<CONFIG>>/PhysXFoundation_64.dll
+        )
+    endif()
 endif()
 
 add_library(${TARGET_WITH_NAMESPACE} INTERFACE IMPORTED GLOBAL)

--- a/package-system/Blast/build_package_image.py
+++ b/package-system/Blast/build_package_image.py
@@ -88,7 +88,6 @@ class BlastBuilder(object):
             staticIgnores = [
                 'PhysXCommon_64.dll',
                 'PhysXCooking_64.dll',
-                'PhysXFoundation_64.dll',
                 'PhysXGpu_64.dll',
                 'PhysX_64.dll',
                 'ApexImporter_x64.exe',
@@ -187,7 +186,7 @@ def main():
         builder.writePackageInfoFile(
             packageRoot,
             settings={
-                'PackageName': f'Blast-v1.1.7_rc2-9-geb169fe-rev1-{args.platformName}',
+                'PackageName': f'Blast-v1.1.7_rc2-9-geb169fe-rev2-{args.platformName}',
                 'URL': 'https://github.com/NVIDIAGameWorks/Blast',
                 'License': 'custom',
                 'LicenseFile': 'Blast/license.txt',

--- a/package_build_list_host_windows.json
+++ b/package_build_list_host_windows.json
@@ -6,7 +6,7 @@
     "build_from_source" : {
         "AWSNativeSDK-1.7.167-rev3-windows" : "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Windows --package-root ../../package-system --clean",
         "AWSNativeSDK-1.7.167-rev6-android" : "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Android --package-root ../../package-system --clean",
-        "Blast-v1.1.7_rc2-9-geb169fe-rev1-windows": "package-system/Blast/build_package_image.py --platform-name windows",
+        "Blast-v1.1.7_rc2-9-geb169fe-rev2-windows": "package-system/Blast/build_package_image.py --platform-name windows",
         "Crashpad-0.8.0-rev1-windows" : "package-system/Crashpad/build_package_image.py",
         "Lua-5.3.5-rev5-windows" : "Scripts/extras/pull_and_build_from_git.py ../../package-system/Lua --platform-name Windows --package-root ../../package-system --clean",
         "Lua-5.3.5-rev5-android" : "Scripts/extras/pull_and_build_from_git.py ../../package-system/Lua --platform-name Android --package-root ../../package-system --clean",
@@ -45,7 +45,7 @@
     "AWSGameLiftServerSDK-3.4.1-rev1-windows" : "package-system/AWSGameLiftServerSDK/windows",
     "AWSNativeSDK-1.7.167-rev3-windows": "package-system/AWSNativeSDK-windows",
     "AWSNativeSDK-1.7.167-rev6-android": "package-system/AWSNativeSDK-android",
-    "Blast-v1.1.7_rc2-9-geb169fe-rev1-windows": "package-system/Blast-windows",
+    "Blast-v1.1.7_rc2-9-geb169fe-rev2-windows": "package-system/Blast-windows",
     "Crashpad-0.8.0-rev1-windows" : "package-system/Crashpad-windows",
     "Lua-5.3.5-rev5-windows": "package-system/Lua-windows",
     "Lua-5.3.5-rev5-android": "package-system/Lua-android",


### PR DESCRIPTION
When building O3DE monolithically the library PhysXFoundation_64.dll won't be present since
PhysX SDK uses a static version of it. Because of this Blast will provide the dll in this case, which
is needed by its extended tools libraries NvBlastExtPhysX_x64.dll and NvBlastExtPxSerialization_x64.dll.

New package for Blast has been created, the version number has been incremented.

Signed-off-by: moraaar <moraaar@amazon.com>