### PR TITLE
convert lz4 to build script

### DIFF
--- a/package-system/lz4/Findlz4.cmake
+++ b/package-system/lz4/Findlz4.cmake
@@ -1,0 +1,45 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(LIB_NAME "lz4")
+
+set(TARGET_WITH_NAMESPACE "3rdParty::${LIB_NAME}")
+if (TARGET ${TARGET_WITH_NAMESPACE})
+    return()
+endif()
+
+set(${LIB_NAME}_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/${LIB_NAME}/${LIB_NAME}/include)
+set(${LIB_NAME}_LIBS_DIR ${CMAKE_CURRENT_LIST_DIR}/${LIB_NAME}/${LIB_NAME}/lib)
+
+if (${PAL_PLATFORM_NAME} STREQUAL "Windows")
+    set(${LIB_NAME}_LIBRARY_DEBUG   ${${LIB_NAME}_LIBS_DIR}/../debug/lib/lz4d.lib)
+    set(${LIB_NAME}_LIBRARY_RELEASE ${${LIB_NAME}_LIBS_DIR}/lz4.lib)
+elseif(${PAL_PLATFORM_NAME} STREQUAL "Android")
+    set(${LIB_NAME}_LIBRARY_DEBUG   ${${LIB_NAME}_LIBS_DIR}/../debug/lib/liblz4d.a)
+    set(${LIB_NAME}_LIBRARY_RELEASE ${${LIB_NAME}_LIBS_DIR}/liblz4.a)
+elseif (${PAL_PLATFORM_NAME} STREQUAL "Mac")
+    set(${LIB_NAME}_LIBRARY_DEBUG   ${${LIB_NAME}_LIBS_DIR}/../debug/lib/liblz4.a)
+    set(${LIB_NAME}_LIBRARY_RELEASE ${${LIB_NAME}_LIBS_DIR}/liblz4.a)
+elseif (${PAL_PLATFORM_NAME} STREQUAL "Linux")
+    set(${LIB_NAME}_LIBRARY_DEBUG   ${${LIB_NAME}_LIBS_DIR}/../debug/lib/liblz4.a)
+    set(${LIB_NAME}_LIBRARY_RELEASE ${${LIB_NAME}_LIBS_DIR}/liblz4.a)
+endif()
+
+set(${LIB_NAME}_LIBRARY
+    "$<$<CONFIG:profile>:${${LIB_NAME}_LIBRARY_RELEASE}>"
+    "$<$<CONFIG:release>:${${LIB_NAME}_LIBRARY_RELEASE}>"
+    "$<$<CONFIG:debug>:${${LIB_NAME}_LIBRARY_DEBUG}>")
+
+add_library(${TARGET_WITH_NAMESPACE} INTERFACE IMPORTED GLOBAL)
+ly_target_include_system_directories(
+    TARGET ${TARGET_WITH_NAMESPACE} INTERFACE ${${LIB_NAME}_INCLUDE_DIR})
+target_link_libraries(
+    ${TARGET_WITH_NAMESPACE}
+    INTERFACE ${${LIB_NAME}_LIBRARY})
+
+set(${LIB_NAME}_FOUND True)

--- a/package-system/lz4/build_package_image.py
+++ b/package-system/lz4/build_package_image.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import argparse
+import shutil
+
+import sys
+sys.path.append(str(Path(__file__).parent.parent.parent / 'Scripts'))
+from builders.vcpkgbuilder import VcpkgBuilder
+import builders.monkeypatch_tempdir_cleanup
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--platform-name',
+        dest='platformName',
+        choices=['windows', 'android', 'mac', 'ios', 'linux'],
+        default=VcpkgBuilder.defaultPackagePlatformName(),
+    )
+    args = parser.parse_args()
+
+    packageSystemDir = Path(__file__).resolve().parents[1]
+    packageSourceDir = packageSystemDir / 'lz4'
+    outputDir = packageSystemDir / f'lz4-{args.platformName}'
+
+    cmakeFindFile = packageSourceDir / f'Findlz4_{args.platformName}.cmake'
+    if not cmakeFindFile.exists():
+        cmakeFindFile = packageSourceDir / 'Findlz4.cmake'
+
+    with TemporaryDirectory() as tempdir:
+        tempdir = Path(tempdir)
+        
+        builder = VcpkgBuilder(
+            packageName='lz4',
+            portName='lz4',
+            vcpkgDir=tempdir,
+            targetPlatform=args.platformName,
+            static=True
+        )
+        
+        builder.cloneVcpkg('751fc199af8d33eb300af5edbd9e3b77c48f0bca')
+        builder.bootstrap()
+        builder.build()
+        
+        builder.copyBuildOutputTo(
+            outputDir,
+            extraFiles={
+                next(builder.vcpkgDir.glob(f'buildtrees/lz4/src/*/LICENSE')): outputDir / builder.packageName / 'LICENSE',
+                next(builder.vcpkgDir.glob(f'buildtrees/lz4/src/*/README.md')): outputDir / builder.packageName / 'README.md',
+            },
+            subdir='lz4'
+        )
+        
+        # vcpkg's commit 751fc19 uses lz4 version 2.3 at commit 1a49edf
+        builder.writePackageInfoFile(
+            outputDir,
+            settings={
+                'PackageName': f'lz4-1.9.3-vcpkg-rev1-{args.platformName}',
+                'URL': 'https://github.com/lz4/lz4',
+                'License': 'BSD-2-Clause',
+                'LicenseFile': 'lz4/LICENSE'
+            },
+        )
+        
+        shutil.copy2(
+            src=cmakeFindFile,
+            dst=outputDir / 'Findlz4.cmake'
+        )
+
+if __name__ == '__main__':
+    main()

--- a/package_build_list_host_darwin.json
+++ b/package_build_list_host_darwin.json
@@ -39,7 +39,9 @@
         "mikkelsen-1.0.0.4-mac": "package-system/mikkelsen/build_package_image.py --platform mac",
         "mikkelsen-1.0.0.4-ios": "package-system/mikkelsen/build_package_image.py --platform ios",
         "zlib-1.2.11-rev2-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Mac --package-root ../../package-system --clean",
-        "zlib-1.2.11-rev2-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name iOS --package-root ../../package-system --clean"
+        "zlib-1.2.11-rev2-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name iOS --package-root ../../package-system --clean",
+        "lz4-1.9.3-vcpkg-rev1-mac": "package-system/lz4/build_package_image.py --platform-name mac",
+        "lz4-1.9.3-vcpkg-rev1-ios": "package-system/lz4/build_package_image.py --platform-name ios"
     },
     "build_from_folder": {
         "AWSNativeSDK-1.7.167-rev5-mac": "package-system/AWSNativeSDK-mac",
@@ -82,6 +84,8 @@
         "xxhash-0.7.4-rev1-multiplatform": "package-system/xxhash-multiplatform",
         "qt-5.15.2-rev5-mac": "package-system/qt-mac",
         "zlib-1.2.11-rev2-mac": "package-system/zlib-mac",
-        "zlib-1.2.11-rev2-ios": "package-system/zlib-ios"
+        "zlib-1.2.11-rev2-ios": "package-system/zlib-ios",
+        "lz4-1.9.3-vcpkg-rev1-mac": "package-system/lz4-mac",
+        "lz4-1.9.3-vcpkg-rev1-ios": "package-system/lz4-ios"
     }
 }

--- a/package_build_list_host_linux.json
+++ b/package_build_list_host_linux.json
@@ -27,7 +27,8 @@
         "tiff-4.2.0.10-linux": "package-system/tiff/build_package_image.py --platform linux",
         "python-3.7.10-rev2-linux": "package-system/python/build_package_image.py",
         "mikkelsen-1.0.0.4-linux": "package-system/mikkelsen/build_package_image.py",
-        "zlib-1.2.11-rev2-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Linux --package-root ../../package-system --clean"
+        "zlib-1.2.11-rev2-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Linux --package-root ../../package-system --clean",
+        "lz4-1.9.3-vcpkg-rev1-linux": "package-system/lz4/build_package_image.py --platform-name linux"
     },
     "build_from_folder" : {
         "AWSGameLiftServerSDK-3.4.1-rev1-linux": "package-system/AWSGameLiftServerSDK/linux",
@@ -58,6 +59,7 @@
         "SQLite-3.32.2-rev3-multiplatform": "package-system/SQLite-multiplatform",
         "xxhash-0.7.4-rev1-multiplatform": "package-system/xxhash-multiplatform",
         "qt-5.15.2-rev5-linux": "package-system/qt-linux",
-        "zlib-1.2.11-rev2-linux": "package-system/zlib-linux"
+        "zlib-1.2.11-rev2-linux": "package-system/zlib-linux",
+        "lz4-1.9.3-vcpkg-rev1-linux": "package-system/lz4-linux"
     }
 }

--- a/package_build_list_host_windows.json
+++ b/package_build_list_host_windows.json
@@ -41,7 +41,9 @@
         "mikkelsen-1.0.0.4-windows": "package-system/mikkelsen/build_package_image.py",
         "mikkelsen-1.0.0.4-android": "package-system/mikkelsen/build_package_image.py --platform android",
         "zlib-1.2.11-rev2-windows": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Windows --package-root ../../package-system --clean",
-        "zlib-1.2.11-rev2-android": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Android --package-root ../../package-system --clean"
+        "zlib-1.2.11-rev2-android": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Android --package-root ../../package-system --clean",
+        "lz4-1.9.3-vcpkg-rev1-windows": "package-system/lz4/build_package_image.py --platform-name windows",
+        "lz4-1.9.3-vcpkg-rev1-android": "package-system/lz4/build_package_image.py --platform-name android"
       },
   "build_from_folder": {
     "AWSGameLiftServerSDK-3.4.1-rev1-windows" : "package-system/AWSGameLiftServerSDK/windows",
@@ -107,6 +109,8 @@
     "qt-5.15.2-rev4-windows": "package-system/qt-windows",
     "Wwise-2021.1.0.7575-rev1-multiplatform": "package-system/Wwise-multiplatform",
     "zlib-1.2.11-rev2-android": "package-system/zlib-android",
-    "zlib-1.2.11-rev2-windows": "package-system/zlib-windows"
+    "zlib-1.2.11-rev2-windows": "package-system/zlib-windows",
+    "lz4-1.9.3-vcpkg-rev1-windows": "package-system/lz4-windows",
+    "lz4-1.9.3-vcpkg-rev1-android": "package-system/lz4-android"
   }
 }


### PR DESCRIPTION
Can now build lz4 package containing static libs & headers for Windows, Linux, Mac, iOS, & Android

Packaged version of LZ4 has been updated from r128 to 1.9.3 (version supported by vcpkg)