### PR TITLE
Move 3p AWSNativeSDK ios to github

### DIFF
--- a/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.iOS
+++ b/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.iOS
@@ -1,0 +1,312 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+include(CMakeParseArguments)
+
+set(AWSNATIVESDK_PACKAGE_NAME AWSNativeSDK)
+
+set(AWS_BASE_PATH ${CMAKE_CURRENT_LIST_DIR}/${AWSNATIVESDK_PACKAGE_NAME})
+
+# Include Path
+set(AWSNATIVESDK_INCLUDE_PATH ${AWS_BASE_PATH}/include)
+
+# Only static libs are supported for this revision
+set(AWSNATIVE_SDK_LIB_PATH ${AWS_BASE_PATH}/lib/$<IF:$<CONFIG:Debug>,Debug,Release>)
+
+# AWS Compile Definitions
+set(AWSNATIVESDK_COMPILE_DEFINITIONS AWS_CUSTOM_MEMORY_MANAGEMENT PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
+
+find_library(SECURITY_FRAMEWORK Security)
+set(AWSNATIVESDK_BUILD_DEPENDENCIES ${SECURITY_FRAMEWORK})
+
+# Helper function to define individual AWSNativeSDK Libraries
+function(ly_declare_aws_library)
+
+    set(options)
+    set(oneValueArgs NAME LIB_FILE)
+    set(multiValueArgs BUILD_DEPENDENCIES)
+    
+    cmake_parse_arguments(ly_declare_aws_library "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    set(TARGET_WITH_NAMESPACE "3rdParty::${AWSNATIVESDK_PACKAGE_NAME}::${ly_declare_aws_library_NAME}")
+    if (NOT TARGET ${TARGET_WITH_NAMESPACE})
+
+        add_library(${TARGET_WITH_NAMESPACE} INTERFACE IMPORTED GLOBAL)
+
+        ly_target_include_system_directories(TARGET ${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_INCLUDE_PATH})
+
+        if (ly_declare_aws_library_LIB_FILE)
+        
+            target_link_libraries(${TARGET_WITH_NAMESPACE} 
+                INTERFACE
+                    ${AWSNATIVE_SDK_LIB_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}${ly_declare_aws_library_LIB_FILE}${CMAKE_STATIC_LIBRARY_SUFFIX}
+                    ${AWSNATIVESDK_BUILD_DEPENDENCIES}
+                    ${ly_declare_aws_library_BUILD_DEPENDENCIES}
+            )
+                    
+        elseif (ly_declare_aws_library_BUILD_DEPENDENCIES)
+            target_link_libraries(${TARGET_WITH_NAMESPACE} 
+                INTERFACE
+                    ${ly_declare_aws_library_BUILD_DEPENDENCIES}
+            )
+        endif()
+        
+        target_link_options(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_LINK_OPTIONS})
+
+
+        target_compile_definitions(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_COMPILE_DEFINITIONS})
+
+    endif()
+    
+endfunction()
+
+
+#### Common ####
+ly_declare_aws_library(
+    NAME 
+        Common
+    LIB_FILE 
+        aws-c-common
+)       
+
+#### Checksums ####
+ly_declare_aws_library(
+    NAME 
+        Checksums
+    LIB_FILE 
+        aws-checksums
+)
+
+#### EventStream ####
+ly_declare_aws_library(
+    NAME 
+        EventStream
+    LIB_FILE 
+        aws-c-event-stream
+    BUILD_DEPENDENCIES
+        3rdParty::AWSNativeSDK::Checksums
+)
+
+#### Core ####
+ly_declare_aws_library(
+    NAME 
+        Core
+    LIB_FILE 
+        aws-cpp-sdk-core
+    BUILD_DEPENDENCIES
+        ${AWSNATIVE_SDK_LIB_PATH}/libcurl${CMAKE_STATIC_LIBRARY_SUFFIX}
+        3rdParty::AWSNativeSDK::Common
+        3rdParty::AWSNativeSDK::EventStream
+)
+
+#### AccessManagement ####
+ly_declare_aws_library(
+    NAME 
+        AccessManagement
+    LIB_FILE 
+        aws-cpp-sdk-access-management
+)
+
+#### CognitoIdentity ####
+ly_declare_aws_library(
+    NAME 
+        CognitoIdentity
+    LIB_FILE 
+        aws-cpp-sdk-cognito-identity
+)
+
+#### CognitoIdp ####
+ly_declare_aws_library(
+    NAME 
+        CognitoIdp
+    LIB_FILE 
+        aws-cpp-sdk-cognito-idp
+)
+
+#### DeviceFarm ####
+ly_declare_aws_library(
+    NAME 
+        DeviceFarm
+    LIB_FILE 
+        aws-cpp-sdk-devicefarm
+)
+
+#### DynamoDB ####
+ly_declare_aws_library(
+    NAME 
+        DynamoDB
+    LIB_FILE 
+        aws-cpp-sdk-dynamodb
+)
+
+#### GameLift ####
+ly_declare_aws_library(
+    NAME 
+        GameLift
+    LIB_FILE 
+        aws-cpp-sdk-gamelift
+)
+
+#### IdentityManagement ####
+ly_declare_aws_library(
+    NAME 
+        IdentityManagement
+    LIB_FILE 
+        aws-cpp-sdk-identity-management
+)
+
+#### Kinesis ####
+ly_declare_aws_library(
+    NAME 
+        Kinesis
+    LIB_FILE 
+        aws-cpp-sdk-kinesis
+)
+
+#### Lambda ####
+ly_declare_aws_library(
+    NAME 
+        Lambda
+    LIB_FILE 
+        aws-cpp-sdk-lambda
+)
+
+#### MobileAnalytics ####
+ly_declare_aws_library(
+    NAME 
+        MobileAnalytics
+    LIB_FILE 
+        aws-cpp-sdk-mobileanalytics
+)
+
+#### Queues ####
+ly_declare_aws_library(
+    NAME 
+        Queues
+    LIB_FILE 
+        aws-cpp-sdk-queues
+)
+
+#### S3 ####
+ly_declare_aws_library(
+    NAME 
+        S3
+    LIB_FILE 
+        aws-cpp-sdk-s3
+)
+
+#### SNS ####
+ly_declare_aws_library(
+    NAME 
+        SNS
+    LIB_FILE 
+        aws-cpp-sdk-sns
+)
+
+#### SQS ####
+ly_declare_aws_library(
+    NAME 
+        SQS
+    LIB_FILE 
+        aws-cpp-sdk-sqs
+)
+
+#### STS ####
+ly_declare_aws_library(
+    NAME 
+        STS
+    LIB_FILE 
+        aws-cpp-sdk-sts
+)
+
+#### Transfer ####
+ly_declare_aws_library(
+    NAME 
+        Transfer
+    LIB_FILE 
+        aws-cpp-sdk-transfer
+)
+
+
+#########
+######### Grouping Definitions #########
+#########
+
+
+#### Dependencies ####
+ly_declare_aws_library(
+    NAME 
+        Dependencies
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Checksums
+        3rdParty::AWSNativeSDK::Common
+        3rdParty::AWSNativeSDK::EventStream
+)
+
+#### IdentityMetrics ####
+ly_declare_aws_library(
+    NAME 
+        IdentityMetrics
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Dependencies
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::IdentityManagement
+        3rdParty::AWSNativeSDK::STS
+        3rdParty::AWSNativeSDK::MobileAnalytics
+)
+
+#### IdentityLambda ####
+ly_declare_aws_library(
+    NAME 
+        IdentityLambda
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Dependencies
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::IdentityManagement
+        3rdParty::AWSNativeSDK::Lambda
+        3rdParty::AWSNativeSDK::STS
+)
+
+#### GameLiftClient ####
+ly_declare_aws_library(
+    NAME 
+        GameLiftClient
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::GameLift
+        3rdParty::AWSNativeSDK::Dependencies
+)
+
+#### AWSClientAuth ####
+ly_declare_aws_library(
+    NAME 
+        AWSClientAuth
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Dependencies
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::STS
+        3rdParty::AWSNativeSDK::IdentityManagement
+)
+
+
+#### AWSCore ####
+ly_declare_aws_library(
+    NAME 
+        AWSCore
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::Dependencies
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::DynamoDB
+        3rdParty::AWSNativeSDK::Lambda
+        3rdParty::AWSNativeSDK::S3
+)
+

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_ios.sh
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_ios.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+src_path=temp/src
+bld_path=temp/build
+
+configure_and_build_static() {
+    build_type=$1
+
+    echo "CMake Configure $build_type Static"
+    CXXFLAGS="-Wno-deprecated-declarations -Wno-shorten-64-to-32 -fPIC" \
+    cmake -S "$src_path" -B "$bld_path/${build_type}_Static" \
+          -DTARGET_ARCH=APPLE \
+          -DCMAKE_SYSTEM_NAME=Darwin \
+          -DCMAKE_OSX_ARCHITECTURES="arm64" \
+          -DCMAKE_OSX_SYSROOT="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk" \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+          -DCMAKE_CXX_STANDARD=17 \
+          -DENABLE_TESTING=OFF \
+          -DENABLE_RTTI=ON \
+          -DCUSTOM_MEMORY_MANAGEMENT=ON \
+          -DBUILD_ONLY="access-management;cognito-identity;cognito-idp;core;devicefarm;dynamodb;gamelift;identity-management;kinesis;lambda;mobileanalytics;queues;s3;sns;sqs;sts;transfer" \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DCMAKE_BUILD_TYPE=$build_type \
+          -DCURL_LIBRARY="temp/curl_install/lib/libcurl.a" \
+          -DCURL_INCLUDE_DIR="temp/curl_install/include" \
+          -DCMAKE_INSTALL_LIBDIR="lib/$build_type" || (echo "CMake Configure $build_type Static failed" ; exit 1)
+
+    echo "CMake Build $build_type Static to $bld_path/${build_type}_Static"
+    cmake --build "$bld_path/${build_type}_Static" --config $build_type -j 12 || (echo "CMake Build $build_type Static to $bld_path/${build_type}_Static failed" ; exit 1)
+}
+
+make_configure_and_build_curl() {
+  rm -rf "temp/curl"*
+
+  echo "Downloading Curl 7.65.3"
+  (cd temp && curl -o curl-7.65.3.zip "https://curl.se/download/curl-7.65.3.zip") || exit 1
+
+  echo "Extract Curl 7.65.3 source"
+  unzip  temp/curl-7.65.3.zip -d temp || exit 1
+
+  EXISTING_CFLAGS=$CFLAGS
+  export CFLAGS="-arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk -miphoneos-version-min=13.0 -fPIC"
+
+  (cd temp/curl-7.65.3 && ./configure --disable-shared --enable-static --enable-ipv6 --with-secure-transport --host="arm-apple-darwin" --prefix=$(pwd)/../curl_install) || exit 1
+  (cd temp/curl-7.65.3 && make) || exit 1
+  (cd temp/curl-7.65.3 && make install) || exit 1
+
+  export CFLAGS=$EXISTING_CFLAGS
+  EXISTING_CFLAGS=
+}
+
+# TODO: curl cmake is poorly maintained by community, switch to cmake when it is ready
+cmake_configure_and_build_curl() {
+  rm -rf "temp/curl"*
+
+  echo "Cloning Curl 7.65.3"
+  git clone --single-branch --recursive --branch curl-7_65_3 https://github.com/curl/curl.git temp/curl_src
+
+  echo "CMake Configure Curl Debug Static"
+  cmake -S temp/curl_src -B temp/curl_build/Debug_Static \
+        -DTARGET_ARCH=APPLE \
+        -DCMAKE_SYSTEM_NAME=Darwin \
+        -DCMAKE_OSX_ARCHITECTURES="arm64" \
+        -DCMAKE_OSX_SYSROOT="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk" \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
+        -DCMAKE_USE_SECTRANSP=ON \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DCMAKE_BUILD_TYPE=Debug\
+        -DBUILD_CURL_EXE=OFF \
+        -DBUILD_TESTING=OFF \
+        -DBUILD_SHARED_LIBS=OFF 
+
+  echo "CMake Build Curl Debug Static to temp/curl_build/Debug_Static"
+  cmake --build temp/curl_build/Debug_Static --config Debug -j 12
+
+  echo "CMake Install Curl Debug Static to temp/curl_install/Debug_Static"
+  cmake --install temp/curl_build/Debug_Static --prefix temp/curl_install/Debug_Static --config Debug
+}
+
+# Curl Static
+make_configure_and_build_curl || exit 1
+
+# Debug Static
+configure_and_build_static Debug || exit 1
+
+# Release Static
+configure_and_build_static Release || exit 1
+
+echo "Custom Build for AWSNativeSDK finished successfully"
+exit 0

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_ios.sh
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_ios.sh
@@ -54,34 +54,6 @@ make_configure_and_build_curl() {
   EXISTING_CFLAGS=
 }
 
-# TODO: curl cmake is poorly maintained by community, switch to cmake when it is ready
-cmake_configure_and_build_curl() {
-  rm -rf "temp/curl"*
-
-  echo "Cloning Curl 7.65.3"
-  git clone --single-branch --recursive --branch curl-7_65_3 https://github.com/curl/curl.git temp/curl_src
-
-  echo "CMake Configure Curl Debug Static"
-  cmake -S temp/curl_src -B temp/curl_build/Debug_Static \
-        -DTARGET_ARCH=APPLE \
-        -DCMAKE_SYSTEM_NAME=Darwin \
-        -DCMAKE_OSX_ARCHITECTURES="arm64" \
-        -DCMAKE_OSX_SYSROOT="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk" \
-        -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
-        -DCMAKE_USE_SECTRANSP=ON \
-        -DCMAKE_CXX_STANDARD=17 \
-        -DCMAKE_BUILD_TYPE=Debug\
-        -DBUILD_CURL_EXE=OFF \
-        -DBUILD_TESTING=OFF \
-        -DBUILD_SHARED_LIBS=OFF 
-
-  echo "CMake Build Curl Debug Static to temp/curl_build/Debug_Static"
-  cmake --build temp/curl_build/Debug_Static --config Debug -j 12
-
-  echo "CMake Install Curl Debug Static to temp/curl_install/Debug_Static"
-  cmake --install temp/curl_build/Debug_Static --prefix temp/curl_install/Debug_Static --config Debug
-}
-
 # Curl Static
 make_configure_and_build_curl || exit 1
 

--- a/package-system/AWSNativeSDK/build_config.json
+++ b/package-system/AWSNativeSDK/build_config.json
@@ -2,7 +2,7 @@
    "git_url":"https://github.com/aws/aws-sdk-cpp.git",
    "git_tag":"1.7.167",
    "package_name":"AWSNativeSDK",
-   "package_version":"1.7.167-rev3",
+   "package_version":"1.7.167-rev4",
    "package_url":"https://github.com/aws/aws-sdk-cpp",
    "package_license":"Apache-2.0",
    "package_license_file":"LICENSE",
@@ -12,7 +12,6 @@
    "Platforms":{
       "Windows":{
          "Windows":{
-            "package_version":"1.7.167-rev4",
             "cmake_find_source":"FindAWSNativeSDK.cmake.Windows",
             "custom_build_cmd": [
                "build_AWSNativeSDK_windows.cmd"
@@ -31,6 +30,15 @@
             ],
             "custom_install_cmd": [
                "./install_AWSNativeSDK_mac.sh"
+            ]
+         },
+         "iOS":{
+            "cmake_find_source":"FindAWSNativeSDK.cmake.iOS",
+            "custom_build_cmd": [
+               "./build_AWSNativeSDK_ios.sh"
+            ],
+            "custom_install_cmd": [
+               "./install_AWSNativeSDK_ios.sh"
             ]
          }
       },

--- a/package-system/AWSNativeSDK/install_AWSNativeSDK_ios.sh
+++ b/package-system/AWSNativeSDK/install_AWSNativeSDK_ios.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+src_path=temp/src
+bld_path=temp/build
+inst_path=temp/install
+
+out_include_path=$TARGET_INSTALL_ROOT/include
+mkdir -p $out_include_path
+
+out_lib_path=$TARGET_INSTALL_ROOT/lib
+mkdir -p $out_lib_path/Debug
+mkdir -p $out_lib_path/Release
+
+copy_static_libs() {
+    local bld_type=$1
+    echo "Copying static .a to $out_lib_path/$bld_type"
+    cp -f "$inst_path/lib/$bld_type/"*".a" $out_lib_path/$bld_type/ || (echo "Copying static .a to $out_lib_path/$bld_type failed" ; exit 1)
+
+    echo "Copying 3rdParty static .a to $out_lib_path/$bld_type"
+    cp -f "$bld_path/${bld_type}_Static/.deps/install/lib/"*".a" $out_lib_path/$bld_type/ || (echo "Copying 3rdParty static .a to $out_lib_path/$bld_type failed" ; exit 1)
+
+    echo "Copying Curl static .a to $out_lib_path/$bld_type"
+    cp -f "temp/curl_install/lib/"*".a" $out_lib_path/$bld_type/ || (echo "Copying Curl static .a to $out_lib_path/$bld_type failed" ; exit 1)
+}
+
+# Debug
+echo "CMake Install Debug Static to $inst_path"
+cmake --install $bld_path/Debug_Static --prefix $inst_path --config Debug || (echo "CMake Install Debug Static to $inst_path failed" ; exit 1)
+
+copy_static_libs Debug || exit 1
+
+# Release
+echo "CMake Install Release Static to $inst_path"
+cmake --install $bld_path/Release_Static --prefix $inst_path --config Release || (echo "CMake Install Release Static to $inst_path failed" ; exit 1)
+
+copy_static_libs Release || exit 1
+
+echo "Copying include headers to $out_include_path"
+cp -f -R "$inst_path/include/"* $out_include_path/ || (echo "Copying include headers to $out_include_path failed" ; exit 1)
+
+echo "Copying LICENSE.txt to $TARGET_INSTALL_ROOT"
+cp -f $src_path/LICENSE.txt $TARGET_INSTALL_ROOT/ || (echo "Copying LICENSE.txt to $TARGET_INSTALL_ROOT failed" ; exit 1)
+
+echo "Custom Install for AWSNativeSDK finished successfully"
+exit 0

--- a/package_build_list_host_darwin.json
+++ b/package_build_list_host_darwin.json
@@ -5,7 +5,7 @@
     "comment4" : "Note:  Build from source occurs before build_from_folder",
     "build_from_source": {
         "AWSNativeSDK-1.7.167-rev5-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Mac --package-root ../../package-system --clean",
-        "AWSNativeSDK-1.7.167-rev3-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name iOS --package-root ../../package-system --clean",
+        "AWSNativeSDK-1.7.167-rev4-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name iOS --package-root ../../package-system --clean",
         "Lua-5.3.5-rev6-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Lua --platform-name Mac --package-root ../../package-system --clean",
         "Lua-5.3.5-rev5-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Lua --platform-name iOS --package-root ../../package-system --clean",
         "AwsIotDeviceSdkCpp-1.12.2-rev1-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AwsIotDeviceSdkCpp --platform-name Mac --package-root ../../package-system --clean",
@@ -45,7 +45,7 @@
     },
     "build_from_folder": {
         "AWSNativeSDK-1.7.167-rev5-mac": "package-system/AWSNativeSDK-mac",
-        "AWSNativeSDK-1.7.167-rev3-ios": "package-system/AWSNativeSDK-ios",
+        "AWSNativeSDK-1.7.167-rev4-ios": "package-system/AWSNativeSDK-ios",
         "Lua-5.3.5-rev6-mac": "package-system/Lua-mac",
         "Lua-5.3.5-rev5-ios": "package-system/Lua-ios",
         "AwsIotDeviceSdkCpp-1.12.2-rev1-mac": "package-system/AwsIotDeviceSdkCpp-mac",


### PR DESCRIPTION
## Details
1. Move existing FindAWSNativeSDK to github
2. Add custom build and install script for ios

Note: Bump the ios package version as the FindAWSNativeSDK need a copyright update

## Testing
Tested locally
AR testing https://jenkins-pipeline.agscollab.com/blue/organizations/jenkins/O3DE-LY-FORK/detail/LYN-6779/4/pipeline/

Signed-off-by: liug <liug@amazon.com>