### PR TITLE
Move 3p AWSNativeSDK android and upgrade major version to github

### DIFF
--- a/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Android
+++ b/package-system/AWSNativeSDK/FindAWSNativeSDK.cmake.Android
@@ -1,0 +1,338 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+include(CMakeParseArguments)
+
+set(AWSNATIVESDK_PACKAGE_NAME AWSNativeSDK)
+
+set(AWS_BASE_PATH ${CMAKE_CURRENT_LIST_DIR}/${AWSNATIVESDK_PACKAGE_NAME})
+
+# Include Path
+set(AWSNATIVESDK_INCLUDE_PATH ${AWS_BASE_PATH}/include)
+
+# Determine the lib path and any extra build dependencies
+if(LY_MONOLITHIC_GAME)
+    set(AWSNATIVE_SDK_LIB_PATH ${AWS_BASE_PATH}/lib/$<IF:$<CONFIG:Debug>,Debug,Release>)
+    set(AWSNATIVESDK_BUILD_DEPENDENCIES
+        ${AWSNATIVE_SDK_LIB_PATH}/dependencies/${CMAKE_STATIC_LIBRARY_PREFIX}curl${CMAKE_STATIC_LIBRARY_SUFFIX}
+        ${AWSNATIVE_SDK_LIB_PATH}/dependencies/${CMAKE_STATIC_LIBRARY_PREFIX}ssl${CMAKE_STATIC_LIBRARY_SUFFIX}
+        ${AWSNATIVE_SDK_LIB_PATH}/dependencies/${CMAKE_STATIC_LIBRARY_PREFIX}crypto${CMAKE_STATIC_LIBRARY_SUFFIX}
+        ${AWSNATIVE_SDK_LIB_PATH}/dependencies/${CMAKE_STATIC_LIBRARY_PREFIX}z${CMAKE_STATIC_LIBRARY_SUFFIX}
+    )
+else()
+    set(AWSNATIVE_SDK_LIB_PATH ${AWS_BASE_PATH}/bin/$<IF:$<CONFIG:Debug>,Debug,Release>)
+endif()
+
+# AWS Compile Definitions
+set(AWSNATIVESDK_COMPILE_DEFINITIONS AWS_CUSTOM_MEMORY_MANAGEMENT PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
+
+# Helper function to define individual AWSNativeSDK Libraries
+function(ly_declare_aws_library)
+
+    set(options)
+    set(oneValueArgs NAME LIB_FILE)
+    set(multiValueArgs BUILD_DEPENDENCIES)
+    
+    cmake_parse_arguments(ly_declare_aws_library "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    set(TARGET_WITH_NAMESPACE "3rdParty::${AWSNATIVESDK_PACKAGE_NAME}::${ly_declare_aws_library_NAME}")
+    if (NOT TARGET ${TARGET_WITH_NAMESPACE})
+
+        add_library(${TARGET_WITH_NAMESPACE} INTERFACE IMPORTED GLOBAL)
+
+        ly_target_include_system_directories(TARGET ${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_INCLUDE_PATH})
+
+        if (ly_declare_aws_library_LIB_FILE)
+
+            if (LY_MONOLITHIC_GAME)
+                target_link_libraries(${TARGET_WITH_NAMESPACE} 
+                    INTERFACE
+                        ${AWSNATIVE_SDK_LIB_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}${ly_declare_aws_library_LIB_FILE}${CMAKE_STATIC_LIBRARY_SUFFIX}
+                        ${AWSNATIVESDK_BUILD_DEPENDENCIES}
+                        ${ly_declare_aws_library_BUILD_DEPENDENCIES}
+                )
+            else()
+                set(LIB_FILE_PATH ${AWSNATIVE_SDK_LIB_PATH}/${CMAKE_SHARED_LIBRARY_PREFIX}${ly_declare_aws_library_LIB_FILE}${CMAKE_SHARED_LIBRARY_SUFFIX})
+                target_link_libraries(${TARGET_WITH_NAMESPACE} 
+                    INTERFACE
+                        ${LIB_FILE_PATH}
+                        ${AWSNATIVESDK_BUILD_DEPENDENCIES}
+                        ${ly_declare_aws_library_BUILD_DEPENDENCIES}
+                )
+
+                ly_add_dependencies(${TARGET_WITH_NAMESPACE} ${LIB_FILE_PATH})
+
+            endif()
+                    
+        elseif (ly_declare_aws_library_BUILD_DEPENDENCIES)
+            target_link_libraries(${TARGET_WITH_NAMESPACE} 
+                INTERFACE
+                    ${ly_declare_aws_library_BUILD_DEPENDENCIES}
+            )
+        endif()
+        
+        target_link_options(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_LINK_OPTIONS})
+
+        target_compile_definitions(${TARGET_WITH_NAMESPACE} INTERFACE ${AWSNATIVESDK_COMPILE_DEFINITIONS})
+
+    endif()
+    
+endfunction()
+
+#### CRT ####
+if(LY_MONOLITHIC_GAME)
+    ly_declare_aws_library(
+        NAME 
+            AWSCrt
+        LIB_FILE 
+            aws-crt-cpp
+        BUILD_DEPENDENCIES
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-s3${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-auth${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-http${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-io${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-mqtt${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-event-stream${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-checksums${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-common${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-compression${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libaws-c-cal${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${AWSNATIVE_SDK_LIB_PATH}/libs2n${CMAKE_STATIC_LIBRARY_SUFFIX}
+    )
+endif()
+
+#### Core ####
+if(LY_MONOLITHIC_GAME)
+    ly_declare_aws_library(
+        NAME 
+            Core
+        LIB_FILE 
+            aws-cpp-sdk-core
+        BUILD_DEPENDENCIES 
+            3rdParty::AWSNativeSDK::AWSCrt
+    )
+else()
+    ly_declare_aws_library(
+        NAME 
+            Core
+        LIB_FILE 
+            aws-cpp-sdk-core
+    )
+endif()
+
+#### AccessManagement ####
+ly_declare_aws_library(
+    NAME 
+        AccessManagement
+    LIB_FILE 
+        aws-cpp-sdk-access-management
+)
+
+#### CognitoIdentity ####
+ly_declare_aws_library(
+    NAME 
+        CognitoIdentity
+    LIB_FILE 
+        aws-cpp-sdk-cognito-identity
+)
+
+#### CognitoIdp ####
+ly_declare_aws_library(
+    NAME 
+        CognitoIdp
+    LIB_FILE 
+        aws-cpp-sdk-cognito-idp
+)
+
+#### DeviceFarm ####
+ly_declare_aws_library(
+    NAME 
+        DeviceFarm
+    LIB_FILE 
+        aws-cpp-sdk-devicefarm
+)
+
+#### DynamoDB ####
+ly_declare_aws_library(
+    NAME 
+        DynamoDB
+    LIB_FILE 
+        aws-cpp-sdk-dynamodb
+)
+
+#### GameLift ####
+ly_declare_aws_library(
+    NAME 
+        GameLift
+    LIB_FILE 
+        aws-cpp-sdk-gamelift
+)
+
+#### IdentityManagement ####
+ly_declare_aws_library(
+    NAME 
+        IdentityManagement
+    LIB_FILE 
+        aws-cpp-sdk-identity-management
+)
+
+#### Kinesis ####
+ly_declare_aws_library(
+    NAME 
+        Kinesis
+    LIB_FILE 
+        aws-cpp-sdk-kinesis
+)
+
+#### Lambda ####
+ly_declare_aws_library(
+    NAME 
+        Lambda
+    LIB_FILE 
+        aws-cpp-sdk-lambda
+)
+
+#### MobileAnalytics ####
+ly_declare_aws_library(
+    NAME 
+        MobileAnalytics
+    LIB_FILE 
+        aws-cpp-sdk-mobileanalytics
+)
+
+#### Queues ####
+ly_declare_aws_library(
+    NAME 
+        Queues
+    LIB_FILE 
+        aws-cpp-sdk-queues
+)
+
+#### S3 ####
+ly_declare_aws_library(
+    NAME 
+        S3
+    LIB_FILE 
+        aws-cpp-sdk-s3
+)
+
+#### SNS ####
+ly_declare_aws_library(
+    NAME 
+        SNS
+    LIB_FILE 
+        aws-cpp-sdk-sns
+)
+
+#### SQS ####
+ly_declare_aws_library(
+    NAME 
+        SQS
+    LIB_FILE 
+        aws-cpp-sdk-sqs
+)
+
+#### STS ####
+ly_declare_aws_library(
+    NAME 
+        STS
+    LIB_FILE 
+        aws-cpp-sdk-sts
+)
+
+#### Transfer ####
+ly_declare_aws_library(
+    NAME 
+        Transfer
+    LIB_FILE 
+        aws-cpp-sdk-transfer
+)
+
+
+#########
+######### Grouping Definitions #########
+#########
+
+
+#### Dependencies ####
+if(LY_MONOLITHIC_GAME)
+    ly_declare_aws_library(
+        NAME 
+            Dependencies
+        BUILD_DEPENDENCIES 
+            3rdParty::AWSNativeSDK::AWSCrt
+    )
+else()
+    ly_declare_aws_library(
+        NAME 
+            Dependencies
+    )
+endif()
+
+#### IdentityMetrics ####
+ly_declare_aws_library(
+    NAME 
+        IdentityMetrics
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::IdentityManagement
+        3rdParty::AWSNativeSDK::MobileAnalytics
+        3rdParty::AWSNativeSDK::STS
+        3rdParty::AWSNativeSDK::Dependencies
+)
+
+#### IdentityLambda ####
+ly_declare_aws_library(
+    NAME 
+        IdentityLambda
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::IdentityManagement
+        3rdParty::AWSNativeSDK::Lambda
+        3rdParty::AWSNativeSDK::STS
+        3rdParty::AWSNativeSDK::Dependencies
+)
+
+#### GameLiftClient ####
+ly_declare_aws_library(
+    NAME 
+        GameLiftClient
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::GameLift
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::Dependencies
+)
+
+#### AWSClientAuth ####
+ly_declare_aws_library(
+    NAME 
+        AWSClientAuth
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::CognitoIdentity
+        3rdParty::AWSNativeSDK::CognitoIdp
+        3rdParty::AWSNativeSDK::IdentityManagement
+        3rdParty::AWSNativeSDK::STS
+        3rdParty::AWSNativeSDK::Dependencies
+)
+
+
+#### AWSCore ####
+ly_declare_aws_library(
+    NAME 
+        AWSCore
+    BUILD_DEPENDENCIES 
+        3rdParty::AWSNativeSDK::DynamoDB
+        3rdParty::AWSNativeSDK::Lambda
+        3rdParty::AWSNativeSDK::S3
+        3rdParty::AWSNativeSDK::Core
+        3rdParty::AWSNativeSDK::Dependencies
+)
+

--- a/package-system/AWSNativeSDK/build_AWSNativeSDK_android.cmd
+++ b/package-system/AWSNativeSDK/build_AWSNativeSDK_android.cmd
@@ -1,0 +1,81 @@
+@echo off
+REM 
+REM Copyright (c) Contributors to the Open 3D Engine Project.
+REM For complete copyright and license terms please see the LICENSE at the root of this distribution.
+REM 
+REM SPDX-License-Identifier: Apache-2.0 OR MIT
+REM 
+
+SET SRC_PATH=temp\src
+SET BLD_PATH=temp\build
+
+IF "%ANDROID_NDK_ROOT%"=="" (
+    ECHO "Required envrironment variable ANDROID_NDK_ROOT is missing, please set it to local android ndk directory"
+    exit /b 1
+)
+
+REM Debug Shared
+call:ConfigureAndBuild Debug Shared
+IF %ERRORLEVEL% NEQ 0 (
+    exit /b 1
+)
+
+REM Debug Static
+call:ConfigureAndBuild Debug Static
+IF %ERRORLEVEL% NEQ 0 (
+    exit /b 1
+)
+
+REM Release Shared
+call:ConfigureAndBuild Release Shared
+IF %ERRORLEVEL% NEQ 0 (
+    exit /b 1
+)
+
+REM Release Static
+call:ConfigureAndBuild Release Static
+IF %ERRORLEVEL% NEQ 0 (
+    exit /b 1
+)
+
+ECHO "Custom Build for AWSNativeSDK finished successfully"
+exit /b 0
+
+:ConfigureAndBuild
+SET BUILD_TYPE=%~1
+SET LIB_TYPE=%~2
+SET BUILD_SHARED=OFF
+IF %LIB_TYPE% EQU Shared (
+    SET BUILD_SHARED=ON
+)
+ECHO "CMake Configure %BUILD_TYPE% %LIB_TYPE%"
+call cmake -S %SRC_PATH% -B %BLD_PATH%\%BUILD_TYPE%_%LIB_TYPE% ^
+           -G Ninja ^
+           -DNDK_DIR="%ANDROID_NDK_ROOT%" ^
+           -DBUILD_SHARED_LIBS=%BUILD_SHARED% ^
+           -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" ^
+           -DTARGET_ARCH=ANDROID ^
+           -DANDROID_NATIVE_API_LEVEL=21 ^
+           -DANDROID_ABI=arm64-v8a ^
+           -DCPP_STANDARD=17 ^
+           -DCMAKE_C_FLAGS="-fPIC" ^
+           -DCMAKE_CXX_FLAGS="-fPIC" ^
+           -DBUILD_ONLY="access-management;cognito-identity;cognito-idp;core;devicefarm;dynamodb;gamelift;identity-management;kinesis;lambda;mobileanalytics;queues;s3;sns;sqs;sts;transfer" ^
+           -DENABLE_TESTING=OFF ^
+           -DENABLE_RTTI=ON ^
+           -DCUSTOM_MEMORY_MANAGEMENT=ON^
+           -DCMAKE_INSTALL_BINDIR="bin/%BUILD_TYPE%_%LIB_TYPE%" ^
+           -DCMAKE_INSTALL_LIBDIR="lib/%BUILD_TYPE%_%LIB_TYPE%" ^
+           -DCMAKE_INSTALL_PREFIX="%BLD_PATH%/%BUILD_TYPE%_%LIB_TYPE%"
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "CMake Configure %BUILD_TYPE% %LIB_TYPE% failed"
+    exit /b 1
+)
+
+ECHO "CMake Build %BUILD_TYPE% %LIB_TYPE% to %BLD_PATH%\%BUILD_TYPE%_%LIB_TYPE%"
+call cmake --build %BLD_PATH%\%BUILD_TYPE%_%LIB_TYPE% --config %BUILD_TYPE% -j
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "CMake Build %BUILD_TYPE% %LIB_TYPE% to %BLD_PATH%\%BUILD_TYPE%_%LIB_TYPE% failed"
+    exit /b 1
+)
+GOTO:EOF

--- a/package-system/AWSNativeSDK/build_config.json
+++ b/package-system/AWSNativeSDK/build_config.json
@@ -20,6 +20,17 @@
             "custom_install_cmd": [
                "install_AWSNativeSDK_windows.cmd"
             ]
+         },
+         "Android":{
+            "git_tag":"1.9.50",
+            "package_version":"1.9.50-rev1",
+            "cmake_find_source":"FindAWSNativeSDK.cmake.Android",
+            "custom_build_cmd": [
+               "build_AWSNativeSDK_android.cmd"
+            ],
+            "custom_install_cmd": [
+               "install_AWSNativeSDK_android.cmd"
+            ]
          }
       },
       "Darwin":{

--- a/package-system/AWSNativeSDK/install_AWSNativeSDK_android.cmd
+++ b/package-system/AWSNativeSDK/install_AWSNativeSDK_android.cmd
@@ -1,0 +1,117 @@
+@echo off
+REM
+REM Copyright (c) Contributors to the Open 3D Engine Project.
+REM For complete copyright and license terms please see the LICENSE at the root of this distribution.
+REM 
+REM SPDX-License-Identifier: Apache-2.0 OR MIT
+REM
+
+SET BLD_PATH=temp\build
+SET SRC_PATH=temp\src
+SET INST_PATH=temp\install
+
+SET OUT_BIN_PATH=%TARGET_INSTALL_ROOT%\bin
+mkdir %OUT_BIN_PATH%\Debug
+mkdir %OUT_BIN_PATH%\Release
+
+SET OUT_INCLUDE_PATH=%TARGET_INSTALL_ROOT%\include
+mkdir %OUT_INCLUDE_PATH%
+
+SET OUT_LIB_PATH=%TARGET_INSTALL_ROOT%\lib
+mkdir %OUT_LIB_PATH%\Debug\dependencies
+mkdir %OUT_LIB_PATH%\Release\dependencies
+
+REM CMake Install Debug and 3rdParty
+ECHO "CMake Install Debug Shared to %INST_PATH%"
+call cmake --install %BLD_PATH%\Debug_Shared --prefix %INST_PATH% --config Debug
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "CMake Install Debug Shared to %INST_PATH% failed"
+    exit /b 1
+)
+
+ECHO "CMake Install Debug Static to %INST_PATH%"
+call cmake --install %BLD_PATH%\Debug_Static --prefix %INST_PATH% --config Debug
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "CMake Install Debug Static to %INST_PATH% failed"
+    exit /b 1
+)
+
+call:CopyDynamicAndStaticLibs "Debug"
+IF %ERRORLEVEL% NEQ 0 (
+    exit /b 1
+)
+
+REM CMake Install Release and 3rdParty
+ECHO "CMake Install Release Shared to %INST_PATH%"
+call cmake --install %BLD_PATH%\Release_Shared --prefix %INST_PATH% --config Release
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "CMake Install Release Shared to %INST_PATH% failed"
+    exit /b 1
+)
+
+ECHO "CMake Install Release Static to %INST_PATH%"
+call cmake --install %BLD_PATH%\Release_Static --prefix %INST_PATH% --config Release
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "CMake Install Release Static to %INST_PATH% failed"
+    exit /b 1
+)
+
+call:CopyDynamicAndStaticLibs "Release"
+IF %ERRORLEVEL% NEQ 0 (
+    exit /b 1
+)
+
+REM Copy include headers
+ECHO "Copying include headers to %OUT_INCLUDE_PATH%"
+Xcopy %INST_PATH%\include\* %OUT_INCLUDE_PATH% /E /Y
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying include headers to %OUT_INCLUDE_PATH% failed"
+    exit /b 1
+)
+
+REM Copy license
+ECHO "Copying LICENSE.TXT to %TARGET_INSTALL_ROOT%"
+copy /Y %SRC_PATH%\LICENSE.TXT %TARGET_INSTALL_ROOT%
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying LICENSE.TXT to %TARGET_INSTALL_ROOT% failed"
+    exit /b 1
+)
+
+ECHO "Custom Install for AWSNativeSDK finished successfully"
+exit /b 0
+
+:CopyDynamicAndStaticLibs
+SET BUILD_TYPE=%~1
+ECHO "Copying shared .so to %OUT_BIN_PATH%\%BUILD_TYPE%"
+copy /Y %INST_PATH%\lib\%BUILD_TYPE%_Shared\*.so %OUT_BIN_PATH%\%BUILD_TYPE%\
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying shared .so to %OUT_BIN_PATH%\%BUILD_TYPE% failed"
+    exit /b 1
+)
+
+ECHO "Copying static .a to %OUT_LIB_PATH%\%BUILD_TYPE%"
+copy /Y %INST_PATH%\lib\%BUILD_TYPE%_Static\*.a %OUT_LIB_PATH%\%BUILD_TYPE%\
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying static .a to %OUT_LIB_PATH%\%BUILD_TYPE% failed"
+    exit /b 1
+)
+
+ECHO "Copying curl openssl and zlib static .a to %OUT_LIB_PATH%\%BUILD_TYPE%\dependencies"
+copy /Y %BLD_PATH%\%BUILD_TYPE%_Static\external-install\curl\lib\*.a %OUT_LIB_PATH%\%BUILD_TYPE%\dependencies\
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying 3rdParty static .a to %OUT_LIB_PATH%\%BUILD_TYPE%\dependencies failed"
+    exit /b 1
+)
+
+copy /Y %BLD_PATH%\%BUILD_TYPE%_Static\external-install\openssl\lib\*.a %OUT_LIB_PATH%\%BUILD_TYPE%\dependencies\
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying 3rdParty static .a to %OUT_LIB_PATH%\%BUILD_TYPE%\dependencies failed"
+    exit /b 1
+)
+
+copy /Y %BLD_PATH%\%BUILD_TYPE%_Static\external-install\zlib\lib\*.a %OUT_LIB_PATH%\%BUILD_TYPE%\dependencies\
+IF %ERRORLEVEL% NEQ 0 (
+    ECHO "Copying 3rdParty static .a to %OUT_LIB_PATH%\%BUILD_TYPE%\dependencies failed"
+    exit /b 1
+)
+GOTO:EOF

--- a/package_build_list_host_windows.json
+++ b/package_build_list_host_windows.json
@@ -3,9 +3,9 @@
     "comment2" : "build_from_source is package name --> build script to call with params",
     "comment3" : "build_from_folder is package name --> folder containing built image of package",
     "comment4" : "Note:  Build from source occurs before build_from_folder",
-    "build_from_source": {
-        "AWSNativeSDK-1.7.167-rev4-windows": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Windows --package-root ../../package-system --clean",
-        "AWSNativeSDK-1.7.167-rev6-android": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Android --package-root ../../package-system --clean",
+    "build_from_source" : {
+        "AWSNativeSDK-1.7.167-rev4-windows" : "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Windows --package-root ../../package-system --clean",
+        "AWSNativeSDK-1.9.50-rev1-android" : "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Android --package-root ../../package-system --clean",
         "Blast-v1.1.7_rc2-9-geb169fe-rev2-windows": "package-system/Blast/build_package_image.py --platform-name windows",
         "Crashpad-0.8.0-rev1-windows": "package-system/Crashpad/build_package_image.py",
         "Lua-5.3.5-rev5-windows": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Lua --platform-name Windows --package-root ../../package-system --clean",


### PR DESCRIPTION
## Details
Add custom build and install script for android, and bump android package major version
Here we do package major version bump for  android first as new aws sdk cpp helps to solve the sdk dependency build issue, other platforms major version bump will be tracked separately

## Testing
Tested locally

AR testing https://jenkins-pipeline.agscollab.com/blue/organizations/jenkins/O3DE-LY-FORK/detail/LYN-6779/2/pipeline

Signed-off-by: Liu <liug@amazon.com>