### PR TITLE
Changed Path.unlink to catch FileNotFoundError instead of using missing_ok param, which wasn't added until Python 3.8

### DIFF
--- a/Scripts/extras/package_downloader.py
+++ b/Scripts/extras/package_downloader.py
@@ -81,7 +81,10 @@ class PackageDownloader():
         
         server_list = server_urls.split(';')
 
-        package_download_name.unlink(missing_ok=True)
+        try:
+            package_download_name.unlink()
+        except FileNotFoundError:
+            pass
         download_location.mkdir(parents=True, exist_ok=True)
 
         print(f"Downloading package {package_name}...")


### PR DESCRIPTION
Modified `pathlib.Path` usage of `unlink` API to catch the `FileNotFoundError` instead of using the `missing_ok` parameter, since that parameter wasn't added until Python 3.8, whereas our current Python runtime is 3.7.10.

Tested using the `depends_on_packages` feature and verified it still pulls download the dependency properly.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>