### PR TITLE
Added support for being able to dynamically reference the python executable that launched the build script from the build_config.json

### DIFF
--- a/Scripts/extras/pull_and_build_from_git.py
+++ b/Scripts/extras/pull_and_build_from_git.py
@@ -674,8 +674,9 @@ class BuildInfo(object):
         env_to_use = self.create_custom_env()
         custom_build_cmds = self.platform_config.get('custom_build_cmd', [])
         for custom_build_cmd in custom_build_cmds:
-
-            call_result = subprocess.run(custom_build_cmd,
+            # Support the user specifying {python} in the custom_build_cmd to invoke
+            # the Python executable that launched this build script
+            call_result = subprocess.run(custom_build_cmd.format(python=sys.executable),
                                          shell=True,
                                          capture_output=False,
                                          cwd=str(self.base_folder),


### PR DESCRIPTION
When using the `custom_build_cmd` in a `build_config.json`, it would be useful to be able to invoke the python executable that ran the build script (e.g. the python runtime from the O3DE engine), since the `python` on the system PATH might not be the one you would want to invoke.

This would allow you to do something like this:

```
"custom_build_cmd": [
    "{python} foo.py",
    "./someOtherScript.sh"
],
```

The use-case that I found for this is I'm working on a build script for Qt on Mac where I'd like to execute a python script using our Python3 executable, because the default python on the system PATH is still Python 2.7.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>