### PR TITLE
Expat conversion

### DIFF
--- a/Scripts/extras/pull_and_build_from_git.py
+++ b/Scripts/extras/pull_and_build_from_git.py
@@ -61,14 +61,23 @@ The following keys can exist at the root level or the target-platform level:
 * cmake_src_subfolder   : (optional) Some packages don't have a CMakeLists at the root and instead its in a subfolder.
                                     In this case, set this to be the relative path from the src root to the folder that
                                     contains the CMakeLists.txt.
-
+* cmake_generate_args_common : (optional) When used at the root, this provides a set of cmake arguments for generation which will 
+                                apply to ALL platforms and configs (appended to cmake_generate_args).
+                                Can be overriden by a specific platform by specifying it in the platform specific section.
+                                The final args will be (cmake_generate_args || cmake_generation_args_CONFIG) + cmake_generate_args_common
+* cmake_build_args_common : (optional) When used at the root, provides a set of cmake arguments for building which will apply to ALL
+                            platforms and configurations.
+                            The final args will be (cmake_build_args || cmake_build_args_CONFIG) + cmake_build_args_common
+                            `cmake --build (build folder) --config config` will automatically be supplied.
+ 
 The following keys can only exist at the target platform level as they describe the specifics for that platform.
 
 * cmake_generate_args                     : The cmake generation arguments (minus the build folder target or any configuration) for generating 
                                             the project for the platform (for all configurations). To perform specific generation commands (i.e.
                                             for situations where the generator does not support multiple configs) the key can contain the 
-                                            suffix of the configuration name (cmake_generate_args_debug, cmake_generate_args_release)
-                                            
+                                            suffix of the configuration name (cmake_generate_args_debug, cmake_generate_args_release).
+                                            For common args that should apply to every config, see cmake_generate_args_common above.
+
 * cmake_build_args                        : Additional build args to pass to cmake during the cmake build command
 
 * cmake_install_filter                    : Optional list of filename patterns to filter what is actually copied to the target package based on
@@ -223,7 +232,8 @@ class PackageInfo(object):
         self.additional_src_files = _get_value("additional_src_files", required=False)
         self.depends_on_packages = _get_value("depends_on_packages", required=False)
         self.cmake_src_subfolder = _get_value("cmake_src_subfolder")
-
+        self.cmake_generate_args_common = _get_value("cmake_generate_args_common")
+        self.cmake_build_args_common = _get_value("cmake_build_args_common")
         if self.cmake_find_template and self.cmake_find_source:
             raise BuildError("Bad build config file. 'cmake_find_template' and 'cmake_find_source' cannot both be set in the configuration.")            
         if not self.cmake_find_template and not self.cmake_find_source:
@@ -554,8 +564,6 @@ class BuildInfo(object):
             # Otherwise install directly to the target
             install_target_folder = self.build_install_folder
 
-        build_args = validate_args(self.platform_config.get('cmake_build_args', []))
-
         can_skip_generate = False
 
         for config in self.build_configs:
@@ -566,6 +574,10 @@ class BuildInfo(object):
                     cmake_generator_args = self.platform_config.get('cmake_generate_args')
                     # Can skip generate the next time since there is only 1 unique cmake generation
                     can_skip_generate = True
+
+                # if there is a cmake_generate_args_common key in the build config, then start with that.
+                if self.package_info.cmake_generate_args_common:
+                    cmake_generator_args = cmake_generator_args + self.package_info.cmake_generate_args_common
 
                 validate_args(cmake_generator_args)
 
@@ -608,6 +620,9 @@ class BuildInfo(object):
                                self.platform_config.get('cmake_build_args') or \
                                []
 
+            if self.package_info.cmake_build_args_common:
+                cmake_build_args = cmake_build_args + self.package_info.cmake_build_args_common
+
             validate_args(cmake_build_args)
 
             cmake_build_cmd = [self.cmake_command,
@@ -616,7 +631,7 @@ class BuildInfo(object):
             if custom_cmake_install:
                 cmake_build_cmd.extend(['--target', 'install'])
 
-            cmake_build_cmd.extend(build_args)
+            cmake_build_cmd.extend(cmake_build_args)
 
             call_result = subprocess.run(subp_args(cmake_build_cmd),
                                          shell=True,

--- a/package-system/expat/Findexpat.cmake
+++ b/package-system/expat/Findexpat.cmake
@@ -1,0 +1,49 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# the following is like an include guard:
+if (TARGET 3rdParty::expat)
+    return()
+endif()
+
+# Even though expat itself exports it as lowercase expat, older cmake (and cmake's built-in targets)
+# expect uppercase.  So we define both, for backwards compat:
+
+set(EXPAT_LIBRARY ${CMAKE_CURRENT_LIST_DIR}/expat/lib/${CMAKE_STATIC_LIBRARY_PREFIX}expat${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(expat_LIBRARY ${EXPAT_LIBRARY})
+
+set(EXPAT_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/expat/include)
+set(expat_INCLUDE_DIR ${EXPAT_INCLUDE_DIR})
+
+set(EXPAT_FOUND TRUE)
+set(expat_FOUND TRUE)
+
+add_library(expat::expat STATIC IMPORTED GLOBAL)
+set_target_properties(expat::expat PROPERTIES IMPORTED_LOCATION ${EXPAT_LIBRARY})
+
+if (COMMAND ly_target_include_system_directories)
+    # inside the O3DE ecosystem, this macro makes sure it works even in cmake < 3.19
+    ly_target_include_system_directories(TARGET expat::expat INTERFACE ${EXPAT_INCLUDE_DIR})
+else()
+    # outside the O3DE ecosystem, we do our best...
+    target_include_directories(expat::expat SYSTEM INTERFACE ${EXPAT_INCLUDE_DIR})
+endif()
+
+# create O3DE aliases:
+add_library(3rdParty::expat ALIAS expat::expat)
+
+# upppercase for compat:
+add_library(EXPAT::EXPAT ALIAS expat::expat)
+
+# if we're not in O3DE, it's also extremely helpful to show a message to logs that indicate that this
+# library was successfully picked up, as opposed to the system one.
+# A good way to know if you're in O3DE or not is that O3DE sets various cache variables before 
+# calling find_package, specifically, LY_VERSION_ENGINE_NAME is always set very early:
+if (NOT LY_VERSION_ENGINE_NAME)
+    message(STATUS "Using O3DE expat ${expat_VERSION} from ${CMAKE_CURRENT_LIST_DIR}")
+endif()

--- a/package-system/expat/Findexpat.cmake
+++ b/package-system/expat/Findexpat.cmake
@@ -39,7 +39,7 @@ set(expat_FOUND TRUE)
 add_library(expat::expat STATIC IMPORTED GLOBAL)
 set_target_properties(expat::expat PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C")
 set_target_properties(expat::expat PROPERTIES IMPORTED_LOCATION ${EXPAT_LIBRARY})
-target_compile_definitions(expat::expat INTERFACE -DXML_STATIC)
+target_compile_definitions(expat::expat INTERFACE XML_STATIC)
 
 if (COMMAND ly_target_include_system_directories)
     # inside the O3DE ecosystem, this macro makes sure it works even in cmake < 3.19

--- a/package-system/expat/build_config.json
+++ b/package-system/expat/build_config.json
@@ -1,0 +1,103 @@
+{
+    "git_url":"https://github.com/libexpat/libexpat",
+    "git_tag":"R_2_4_2",
+    "package_name":"expat",
+    "package_version":"2.4.2-rev1",
+    "package_url":"https://libexpat.github.io/",
+    "package_license":"MIT",
+    "package_license_file":"expat/COPYING",
+    "cmake_find_source":"Findexpat.cmake",
+    "cmake_find_target":"Findexpat.cmake",
+    "cmake_src_subfolder": "expat",
+    "Platforms":{
+        "Windows":{
+          "Windows": {
+              "custom_cmake_install": true,
+              "cmake_generate_args_release": [
+                  "-G",
+                  "\"Visual Studio 16 2019\"",
+                  "-DCMAKE_CXX_STANDARD=17",
+                  "-DBUILD_SHARED_LIBS=0"
+              ],
+              "cmake_build_args": [
+                  "-j"
+              ],
+              "build_configs": [
+                  "Release"
+              ]
+          }
+        },
+        "Darwin": {
+          "Mac": {
+              "custom_cmake_install": true,
+              "cmake_generate_args_release": [
+                  "-G",
+                  "Xcode",
+                  "-DEXPAT_BUILD_DOCS=OFF",
+                  "-DEXPAT_BUILD_TOOLS=OFF",
+                  "-DEXPAT_BUILD_EXAMPLES=OFF",
+                  "-DEXPAT_SHARED_LIBS=OFF",
+                  "-DEXPAT_BUILD_FUZZERS=OFF",
+                  "-DEXPAT_BUILD_TESTS=OFF",
+                  "-DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/Mac/Toolchain_mac.cmake",
+                  "-DBUILD_SHARED_LIBS=0"
+              ],
+              "cmake_build_args": [
+                  "--parallel"
+              ],
+              "build_configs": [
+                  "Release"
+              ],
+              "custom_test_cmd" : [
+                "./test_expat_mac.sh"
+            ]
+          },
+          "iOS" : {
+            "custom_cmake_install": true,
+            "cmake_generate_args_release": [
+                "-G",
+                "Xcode",
+                "-DDCMAKE_MACOSX_BUNDLE=OFF",
+                "-DEXPAT_BUILD_DOCS=OFF",
+                "-DEXPAT_BUILD_TOOLS=OFF",
+                "-DEXPAT_BUILD_EXAMPLES=OFF",
+                "-DEXPAT_SHARED_LIBS=OFF",
+                "-DEXPAT_BUILD_FUZZERS=OFF",
+                "-DEXPAT_BUILD_TESTS=OFF",
+                "-DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/iOS/Toolchain_ios.cmake",
+                "-DBUILD_SHARED_LIBS=0"
+            ],
+            "cmake_build_args": [
+                "--parallel"
+            ],
+            "build_configs": [
+                "Release"
+            ],
+            "custom_test_cmd" : [
+              "./test_expat_ios.sh"
+            ]
+          }
+        },
+        "Linux":{
+           "Linux":{
+              "custom_cmake_install":true,
+              "cmake_generate_args_release": [
+                  "-G",
+                  "Unix\\ Makefiles",
+                  "-DCMAKE_C_COMPILER=clang-6.0",
+                  "-DCMAKE_CXX_COMPILER=clang++-6.0",
+                  "-DCMAKE_CXX_FLAGS=\"-fPIC -O2\"",
+                  "-DCMAKE_CXX_STANDARD=17",
+                  "-DCMAKE_BUILD_TYPE=Release",
+                  "-DBUILD_SHARED_LIBS=0"
+              ],
+              "cmake_build_args":[
+                 "-j"
+              ],
+              "build_configs":[
+                  "Release"
+              ]
+           }
+        }
+     }
+}

--- a/package-system/expat/build_config.json
+++ b/package-system/expat/build_config.json
@@ -13,19 +13,53 @@
         "Windows":{
           "Windows": {
               "custom_cmake_install": true,
-              "cmake_generate_args_release": [
+              "cmake_generate_args": [
                   "-G",
                   "\"Visual Studio 16 2019\"",
                   "-DCMAKE_CXX_STANDARD=17",
+                  "-DEXPAT_BUILD_DOCS=OFF",
+                  "-DEXPAT_BUILD_TOOLS=OFF",
+                  "-DEXPAT_BUILD_EXAMPLES=OFF",
+                  "-DEXPAT_SHARED_LIBS=OFF",
+                  "-DEXPAT_BUILD_FUZZERS=OFF",
+                  "-DEXPAT_BUILD_TESTS=OFF",
                   "-DBUILD_SHARED_LIBS=0"
               ],
               "cmake_build_args": [
-                  "-j"
+                  "--parallel"
               ],
               "build_configs": [
                   "Release"
+              ],
+              "custom_test_cmd" : [
+                "test_expat_windows.cmd"
               ]
-          }
+          },
+          "Android": {
+            "custom_cmake_install": true,
+            "cmake_generate_args_release": [
+                "-G",
+                "Ninja",
+                "-DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/Android/Toolchain_android.cmake",
+                "-DCMAKE_CXX_STANDARD=17",
+                "-DEXPAT_BUILD_DOCS=OFF",
+                "-DEXPAT_BUILD_TOOLS=OFF",
+                "-DEXPAT_BUILD_EXAMPLES=OFF",
+                "-DEXPAT_SHARED_LIBS=OFF",
+                "-DEXPAT_BUILD_FUZZERS=OFF",
+                "-DEXPAT_BUILD_TESTS=OFF",
+                "-DBUILD_SHARED_LIBS=0"
+            ],
+            "cmake_build_args": [
+                "--parallel"
+            ],
+            "build_configs": [
+                "Release"
+            ],
+            "custom_test_cmd" : [
+                "test_expat_android.cmd"
+              ]
+        }
         },
         "Darwin": {
           "Mac": {
@@ -84,15 +118,17 @@
               "cmake_generate_args_release": [
                   "-G",
                   "Unix\\ Makefiles",
-                  "-DCMAKE_C_COMPILER=clang-6.0",
-                  "-DCMAKE_CXX_COMPILER=clang++-6.0",
-                  "-DCMAKE_CXX_FLAGS=\"-fPIC -O2\"",
                   "-DCMAKE_CXX_STANDARD=17",
-                  "-DCMAKE_BUILD_TYPE=Release",
+                  "-DEXPAT_BUILD_DOCS=OFF",
+                  "-DEXPAT_BUILD_TOOLS=OFF",
+                  "-DEXPAT_BUILD_EXAMPLES=OFF",
+                  "-DEXPAT_SHARED_LIBS=OFF",
+                  "-DEXPAT_BUILD_FUZZERS=OFF",
+                  "-DEXPAT_BUILD_TESTS=OFF",
                   "-DBUILD_SHARED_LIBS=0"
               ],
               "cmake_build_args":[
-                 "-j"
+                 "--parallel"
               ],
               "build_configs":[
                   "Release"

--- a/package-system/expat/build_config.json
+++ b/package-system/expat/build_config.json
@@ -125,6 +125,7 @@
                   "-DEXPAT_SHARED_LIBS=OFF",
                   "-DEXPAT_BUILD_FUZZERS=OFF",
                   "-DEXPAT_BUILD_TESTS=OFF",
+                  "-DCMAKE_C_FLAGS=-fPIC",
                   "-DBUILD_SHARED_LIBS=0"
               ],
               "cmake_build_args":[

--- a/package-system/expat/build_config.json
+++ b/package-system/expat/build_config.json
@@ -9,27 +9,29 @@
     "cmake_find_source":"Findexpat.cmake",
     "cmake_find_target":"Findexpat.cmake",
     "cmake_src_subfolder": "expat",
+    "cmake_generate_args_common": [
+        "-DBUILD_SHARED_LIBS=0",
+        "-DCMAKE_CXX_STANDARD=17",
+        "-DEXPAT_BUILD_DOCS=OFF",
+        "-DEXPAT_BUILD_EXAMPLES=OFF",
+        "-DEXPAT_BUILD_FUZZERS=OFF",
+        "-DEXPAT_BUILD_TESTS=OFF",
+        "-DEXPAT_BUILD_TOOLS=OFF",
+        "-DEXPAT_SHARED_LIBS=OFF"
+    ],
+    "cmake_build_args_common": [
+        "--parallel"
+    ],
+    "build_configs":[
+        "Release"
+    ],
     "Platforms":{
         "Windows":{
           "Windows": {
               "custom_cmake_install": true,
               "cmake_generate_args": [
                   "-G",
-                  "\"Visual Studio 16 2019\"",
-                  "-DCMAKE_CXX_STANDARD=17",
-                  "-DEXPAT_BUILD_DOCS=OFF",
-                  "-DEXPAT_BUILD_TOOLS=OFF",
-                  "-DEXPAT_BUILD_EXAMPLES=OFF",
-                  "-DEXPAT_SHARED_LIBS=OFF",
-                  "-DEXPAT_BUILD_FUZZERS=OFF",
-                  "-DEXPAT_BUILD_TESTS=OFF",
-                  "-DBUILD_SHARED_LIBS=0"
-              ],
-              "cmake_build_args": [
-                  "--parallel"
-              ],
-              "build_configs": [
-                  "Release"
+                  "\"Visual Studio 16 2019\""
               ],
               "custom_test_cmd" : [
                 "test_expat_windows.cmd"
@@ -37,24 +39,10 @@
           },
           "Android": {
             "custom_cmake_install": true,
-            "cmake_generate_args_release": [
+            "cmake_generate_args": [
                 "-G",
                 "Ninja",
-                "-DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/Android/Toolchain_android.cmake",
-                "-DCMAKE_CXX_STANDARD=17",
-                "-DEXPAT_BUILD_DOCS=OFF",
-                "-DEXPAT_BUILD_TOOLS=OFF",
-                "-DEXPAT_BUILD_EXAMPLES=OFF",
-                "-DEXPAT_SHARED_LIBS=OFF",
-                "-DEXPAT_BUILD_FUZZERS=OFF",
-                "-DEXPAT_BUILD_TESTS=OFF",
-                "-DBUILD_SHARED_LIBS=0"
-            ],
-            "cmake_build_args": [
-                "--parallel"
-            ],
-            "build_configs": [
-                "Release"
+                "-DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/Android/Toolchain_android.cmake"
             ],
             "custom_test_cmd" : [
                 "test_expat_android.cmd"
@@ -64,23 +52,10 @@
         "Darwin": {
           "Mac": {
               "custom_cmake_install": true,
-              "cmake_generate_args_release": [
+              "cmake_generate_args": [
                   "-G",
                   "Xcode",
-                  "-DEXPAT_BUILD_DOCS=OFF",
-                  "-DEXPAT_BUILD_TOOLS=OFF",
-                  "-DEXPAT_BUILD_EXAMPLES=OFF",
-                  "-DEXPAT_SHARED_LIBS=OFF",
-                  "-DEXPAT_BUILD_FUZZERS=OFF",
-                  "-DEXPAT_BUILD_TESTS=OFF",
-                  "-DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/Mac/Toolchain_mac.cmake",
-                  "-DBUILD_SHARED_LIBS=0"
-              ],
-              "cmake_build_args": [
-                  "--parallel"
-              ],
-              "build_configs": [
-                  "Release"
+                  "-DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/Mac/Toolchain_mac.cmake"
               ],
               "custom_test_cmd" : [
                 "./test_expat_mac.sh"
@@ -88,24 +63,11 @@
           },
           "iOS" : {
             "custom_cmake_install": true,
-            "cmake_generate_args_release": [
+            "cmake_generate_args": [
                 "-G",
                 "Xcode",
                 "-DDCMAKE_MACOSX_BUNDLE=OFF",
-                "-DEXPAT_BUILD_DOCS=OFF",
-                "-DEXPAT_BUILD_TOOLS=OFF",
-                "-DEXPAT_BUILD_EXAMPLES=OFF",
-                "-DEXPAT_SHARED_LIBS=OFF",
-                "-DEXPAT_BUILD_FUZZERS=OFF",
-                "-DEXPAT_BUILD_TESTS=OFF",
-                "-DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/iOS/Toolchain_ios.cmake",
-                "-DBUILD_SHARED_LIBS=0"
-            ],
-            "cmake_build_args": [
-                "--parallel"
-            ],
-            "build_configs": [
-                "Release"
+                "-DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/iOS/Toolchain_ios.cmake"
             ],
             "custom_test_cmd" : [
               "./test_expat_ios.sh"
@@ -115,24 +77,10 @@
         "Linux":{
            "Linux":{
               "custom_cmake_install":true,
-              "cmake_generate_args_release": [
+              "cmake_generate_args": [
                   "-G",
                   "Unix\\ Makefiles",
-                  "-DCMAKE_CXX_STANDARD=17",
-                  "-DEXPAT_BUILD_DOCS=OFF",
-                  "-DEXPAT_BUILD_TOOLS=OFF",
-                  "-DEXPAT_BUILD_EXAMPLES=OFF",
-                  "-DEXPAT_SHARED_LIBS=OFF",
-                  "-DEXPAT_BUILD_FUZZERS=OFF",
-                  "-DEXPAT_BUILD_TESTS=OFF",
-                  "-DCMAKE_C_FLAGS=-fPIC",
-                  "-DBUILD_SHARED_LIBS=0"
-              ],
-              "cmake_build_args":[
-                 "--parallel"
-              ],
-              "build_configs":[
-                  "Release"
+                  "-DCMAKE_C_FLAGS=-fPIC"
               ],
               "custom_test_cmd" : [
                 "./test_expat_linux.sh"

--- a/package-system/expat/build_config.json
+++ b/package-system/expat/build_config.json
@@ -132,6 +132,9 @@
               ],
               "build_configs":[
                   "Release"
+              ],
+              "custom_test_cmd" : [
+                "./test_expat_linux.sh"
               ]
            }
         }

--- a/package-system/expat/test/CMakeLists.txt
+++ b/package-system/expat/test/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+cmake_minimum_required(VERSION 3.20)
+
+PROJECT(test_expat VERSION 1.0 LANGUAGES C)
+
+find_package(expat)
+
+add_executable(test_expat test_expat.c)
+
+# note that we use 3rdParty::expat here.  This will ONLY work 
+# if the O3DE version of expat is used, which is what we are testing for.
+target_link_libraries(test_expat PRIVATE 3rdParty::expat)
+
+set_target_properties(test_expat PROPERTIES
+                 XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED OFF
+                 MACOSX_BUNDLE TRUE
+                 XCODE_ATTRIBUTE_EXECUTABLE_NAME "test_expat")
+

--- a/package-system/expat/test/example_file.xml
+++ b/package-system/expat/test/example_file.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rootelement>
+    <!-- a comment in here and a utf-8 element. This is not an 
+    exhaustive self test of expat though, it has those in its own code. -->
+    <special-element>✔️</special-element>
+</rootelement>
+

--- a/package-system/expat/test/test_expat.c
+++ b/package-system/expat/test/test_expat.c
@@ -1,0 +1,47 @@
+/*
+ Copyright (c) Contributors to the Open 3D Engine Project.
+ For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ 
+ SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+// test that the TIFF library imports correctly
+// Doesn't test much else about it.  Can be expanded if this becomes a problem in the
+// future.
+
+#include <expat.h>
+#include <stdio.h>
+
+int main()
+{
+    FILE* xmlfile = fopen("example_file.xml", "rb");
+    if (!xmlfile)
+    {
+      printf("Failed to open example_file.xml\n");
+      return 1;
+    }
+    fseek(xmlfile, 0, SEEK_END);
+    int bytes_to_read = (int)ftell(xmlfile);
+    fseek(xmlfile, 0, SEEK_SET);
+    printf("Reading %i bytes from file...\n", bytes_to_read);
+
+    char* databuf = (char*)malloc(bytes_to_read + 1);
+    fread(databuf, 1, bytes_to_read, xmlfile);
+    databuf[bytes_to_read] = 0;
+    fclose(xmlfile);
+
+    printf("invoking EXPAT to parse\n");
+    XML_Parser parser = XML_ParserCreate(0);
+    if (XML_Parse(parser, databuf, bytes_to_read, 1) == XML_STATUS_ERROR) 
+    {
+      printf("Error during reading: %s!\n", XML_ErrorString(XML_GetErrorCode(parser)));
+      return 1;
+    }
+
+    XML_ParserFree(parser);
+
+    printf("Trivial self test SUCCEEDED - no errors from parse.\n");
+
+    return 0;
+
+}

--- a/package-system/expat/test/test_expat.c
+++ b/package-system/expat/test/test_expat.c
@@ -26,7 +26,11 @@ int main()
     printf("Reading %i bytes from file...\n", bytes_to_read);
 
     char* databuf = (char*)malloc(bytes_to_read + 1);
-    fread(databuf, 1, bytes_to_read, xmlfile);
+    if (fread(databuf, 1, bytes_to_read, xmlfile) != bytes_to_read)
+    {
+      printf("Could not read entire example_file.xml");
+      return 0;
+    }
     databuf[bytes_to_read] = 0;
     fclose(xmlfile);
 

--- a/package-system/expat/test_expat_android.cmd
+++ b/package-system/expat/test_expat_android.cmd
@@ -1,0 +1,27 @@
+@rem #
+@rem # Copyright (c) Contributors to the Open 3D Engine Project.
+@rem # For complete copyright and license terms please see the LICENSE at the root of this distribution.
+@rem # 
+@rem # SPDX-License-Identifier: Apache-2.0 OR MIT
+@rem #
+@rem #
+
+rmdir /S /Q  temp\build_test
+mkdir temp\build_test
+
+@rem CMAKE demands forward slashes but PACKAGE_ROOT is in native path:
+set "PACKAGE_ROOT=%PACKAGE_ROOT:\=/%"
+set "DOWNLOADED_PACKAGE_FOLDERS=%DOWNLOADED_PACKAGE_FOLDERS:\=/%"
+
+cmake -S test -B temp/build_test ^
+    -G Ninja ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/Android/Toolchain_android.cmake ^
+    -DCMAKE_MODULE_PATH="%DOWNLOADED_PACKAGE_FOLDERS%;%PACKAGE_ROOT%" || exit /b 1
+
+cmake --build temp/build_test --parallel || exit /b 1
+
+@rem we can't actually run this - its an android binary.  But at least the above
+@rem makes sure it links and that our Findexpat.cmake script is working.
+
+exit /b 0

--- a/package-system/expat/test_expat_ios.sh
+++ b/package-system/expat/test_expat_ios.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+rm -rf temp/build_test
+mkdir temp/build_test
+
+cmake -S test -B temp/build_test -G Xcode \
+    -DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/iOS/Toolchain_ios.cmake \
+    -DCMAKE_MODULE_PATH="$PACKAGE_ROOT" || exit 1
+
+cmake --build temp/build_test --parallel --config Release || exit 1
+
+# we can't actually run it on ios, that'd require an emulator or device as well as
+# cert / signing - but we can at least make sure it compiles!
+
+exit 0
+

--- a/package-system/expat/test_expat_linux.sh
+++ b/package-system/expat/test_expat_linux.sh
@@ -14,10 +14,10 @@ cmake -S test -B temp/build_test -G Ninja -DCMAKE_BUILD_TYPE=Release  \
 
 cmake --build temp/build_test --parallel || exit 1
 
-cd test
+pushd test
 
 ../temp/build_test/test_expat || exit 1
 
-cd ..
+popd
 
 exit 0

--- a/package-system/expat/test_expat_linux.sh
+++ b/package-system/expat/test_expat_linux.sh
@@ -1,0 +1,23 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+rm -rf temp/build_test
+mkdir temp/build_test
+
+cmake -S test -B temp/build_test -G Ninja -DCMAKE_BUILD_TYPE=Release  \
+    -DCMAKE_MODULE_PATH="$DOWNLOADED_PACKAGE_FOLDERS;$PACKAGE_ROOT" || exit 1
+
+cmake --build temp/build_test --parallel || exit 1
+
+cd test
+
+../temp/build_test/test_expat || exit 1
+
+cd ..
+
+exit 0

--- a/package-system/expat/test_expat_mac.sh
+++ b/package-system/expat/test_expat_mac.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+rm -rf temp/build_test
+mkdir temp/build_test
+
+cmake -S test -B temp/build_test -G Xcode \
+    -DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/Mac/Toolchain_mac.cmake \
+    -DCMAKE_MODULE_PATH="$PACKAGE_ROOT" || exit 1
+
+cmake --build temp/build_test --parallel --config Release || exit 1
+pushd test
+../temp/build_test/Release/test_expat.app/Contents/MacOS/test_expat || exit 1
+popd
+exit 0

--- a/package-system/expat/test_expat_windows.cmd
+++ b/package-system/expat/test_expat_windows.cmd
@@ -1,0 +1,29 @@
+@rem #
+@rem # Copyright (c) Contributors to the Open 3D Engine Project.
+@rem # For complete copyright and license terms please see the LICENSE at the root of this distribution.
+@rem # 
+@rem # SPDX-License-Identifier: Apache-2.0 OR MIT
+@rem #
+@rem #
+
+setlocal
+
+rmdir /S /Q  temp\build_test
+mkdir temp\build_test
+
+@rem CMAKE demands forward slashes but PACKAGE_ROOT is in native path:
+set "PACKAGE_ROOT=%PACKAGE_ROOT:\=/%"
+set "DOWNLOADED_PACKAGE_FOLDERS=%DOWNLOADED_PACKAGE_FOLDERS:\=/%"
+
+cmake -S test -B temp/build_test ^
+    -DCMAKE_MODULE_PATH="%DOWNLOADED_PACKAGE_FOLDERS%;%PACKAGE_ROOT%" || exit /b 1
+
+cmake --build temp/build_test --parallel --config Release || exit /b 1
+cmake --build temp/build_test --parallel --config Debug || exit /b 1
+
+cd test
+
+..\temp\build_test\Release\test_expat.exe || exit /b 1
+..\temp\build_test\Debug\test_expat.exe || exit /b 1
+
+exit /b 0

--- a/package_build_list_host_darwin.json
+++ b/package_build_list_host_darwin.json
@@ -46,7 +46,9 @@
         "lz4-1.9.3-vcpkg-rev4-mac": "package-system/lz4/build_package_image.py --platform-name mac",
         "lz4-1.9.3-vcpkg-rev4-ios": "package-system/lz4/build_package_image.py --platform-name ios",
         "tiff-4.2.0.15-rev3-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/tiff --platform-name Mac --package-root ../../package-system --clean",
-        "tiff-4.2.0.15-rev3-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/tiff --platform-name iOS --package-root ../../package-system --clean"
+        "tiff-4.2.0.15-rev3-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/tiff --platform-name iOS --package-root ../../package-system --clean",
+        "expat-2.4.2-rev1-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/expat --platform-name Mac --package-root ../../package-system/expat/temp --clean",
+        "expat-2.4.2-rev1-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/expat --platform-name iOS --package-root ../../package-system/expat/temp --clean"
     },
     "build_from_folder": {
         "AWSNativeSDK-1.9.50-rev1-mac": "package-system/AWSNativeSDK-mac",
@@ -93,6 +95,8 @@
         "zlib-1.2.11-rev5-mac": "package-system/zlib-mac",
         "zlib-1.2.11-rev5-ios": "package-system/zlib-ios",
         "lz4-1.9.3-vcpkg-rev4-mac": "package-system/lz4-mac",
-        "lz4-1.9.3-vcpkg-rev4-ios": "package-system/lz4-ios"
+        "lz4-1.9.3-vcpkg-rev4-ios": "package-system/lz4-ios",
+        "expat-2.4.2-rev1-mac": "package-system/expat/temp/expat-mac",
+        "expat-2.4.2-rev1-ios": "package-system/expat/temp/expat-ios"
     }
 }

--- a/package_build_list_host_linux.json
+++ b/package_build_list_host_linux.json
@@ -33,7 +33,8 @@
         "mikkelsen-1.0.0.4-linux": "package-system/mikkelsen/build_package_image.py",
         "qt-5.15.2-rev5-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Qt --platform-name Linux --package-root ../../package-system --clean",
         "zlib-1.2.11-rev5-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Linux --package-root ../../package-system --clean",
-        "lz4-1.9.3-vcpkg-rev4-linux": "package-system/lz4/build_package_image.py --platform-name linux"
+        "lz4-1.9.3-vcpkg-rev4-linux": "package-system/lz4/build_package_image.py --platform-name linux",
+        "expat-2.4.2-rev1-windows": "Scripts/extras/pull_and_build_from_git.py ../../package-system/expat --platform-name Linux --package-root ../../package-system/expat/temp --clean"
     },
     "build_from_folder": {
         "AWSGameLiftServerSDK-3.4.1-rev1-linux": "package-system/AWSGameLiftServerSDK/linux",
@@ -68,6 +69,7 @@
         "xxhash-0.7.4-rev1-multiplatform": "package-system/xxhash-multiplatform",
         "qt-5.15.2-rev5-linux": "package-system/qt-linux",
         "zlib-1.2.11-rev5-linux": "package-system/zlib-linux",
-        "lz4-1.9.3-vcpkg-rev4-linux": "package-system/lz4-linux"
+        "lz4-1.9.3-vcpkg-rev4-linux": "package-system/lz4-linux",
+        "expat-2.4.2-rev1-linux": "package-system/expat/temp/expat-linux"
     }
 }

--- a/package_build_list_host_linux.json
+++ b/package_build_list_host_linux.json
@@ -34,7 +34,7 @@
         "qt-5.15.2-rev5-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Qt --platform-name Linux --package-root ../../package-system --clean",
         "zlib-1.2.11-rev5-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Linux --package-root ../../package-system --clean",
         "lz4-1.9.3-vcpkg-rev4-linux": "package-system/lz4/build_package_image.py --platform-name linux",
-        "expat-2.4.2-rev1-windows": "Scripts/extras/pull_and_build_from_git.py ../../package-system/expat --platform-name Linux --package-root ../../package-system/expat/temp --clean"
+        "expat-2.4.2-rev1-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/expat --platform-name Linux --package-root ../../package-system/expat/temp --clean"
     },
     "build_from_folder": {
         "AWSGameLiftServerSDK-3.4.1-rev1-linux": "package-system/AWSGameLiftServerSDK/linux",

--- a/package_build_list_host_windows.json
+++ b/package_build_list_host_windows.json
@@ -46,8 +46,10 @@
         "mikkelsen-1.0.0.4-android": "package-system/mikkelsen/build_package_image.py --platform android",
         "qt-5.15.2-rev4-windows": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Qt --platform-name Windows --package-root ../../package-system --clean",
         "zlib-1.2.11-rev1-windows": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Windows --package-root ../../package-system --clean",
-        "zlib-1.2.11-rev1-android": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Android --package-root ../../package-system --clean"
-      },
+        "zlib-1.2.11-rev1-android": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Android --package-root ../../package-system --clean",
+        "expat-2.4.2-rev1-windows": "Scripts/extras/pull_and_build_from_git.py ../../package-system/expat --platform-name Windows --package-root ../../package-system/expat/temp --clean",
+        "expat-2.4.2-rev1-android": "Scripts/extras/pull_and_build_from_git.py ../../package-system/expat --platform-name Android --package-root ../../package-system/expat/temp --clean"
+  },
   "build_from_folder": {
     "astc-encoder-3.2-rev2-windows" : "package-system/astc-encoder-windows",
     "AWSGameLiftServerSDK-3.4.1-rev1-windows" : "package-system/AWSGameLiftServerSDK/windows",
@@ -115,6 +117,8 @@
     "qt-5.15.2-rev4-windows": "package-system/qt-windows",
     "Wwise-2021.1.0.7575-rev1-multiplatform": "package-system/Wwise-multiplatform",
     "zlib-1.2.11-rev1-android": "package-system/zlib-android",
-    "zlib-1.2.11-rev1-windows": "package-system/zlib-windows"
+    "zlib-1.2.11-rev1-windows": "package-system/zlib-windows",
+    "expat-2.4.2-rev1-android": "package-system/expat/temp/expat-android",
+    "expat-2.4.2-rev1-windows": "package-system/expat/temp/expat-windows"
   }
 }


### PR DESCRIPTION
Adds a new option to the pull_and_build_from_git.py script to allow packages that do not have a cmakelists in their root folder but instead in a subfolder.

Moves expat to the latest stable release and adds build scripts for it
