### PR TITLE
AZSLc: Fixed incorrect case in copy command that missed the final exe…

### DIFF
--- a/package-system/azslc/install_azslc_linux.sh
+++ b/package-system/azslc/install_azslc_linux.sh
@@ -20,6 +20,6 @@ cp -f $SRC_PATH/LICENSE_MIT.TXT $TARGET_INSTALL_ROOT/
 
 mkdir -p $BIN_PATH/Release
 
-cp -f $SRC_PATH/build/release/azslc $BIN_PATH/Release/
+cp -f $SRC_PATH/build/Release/azslc $BIN_PATH/Release/
 
 exit 0

--- a/package-system/azslc/install_azslc_mac.sh
+++ b/package-system/azslc/install_azslc_mac.sh
@@ -20,6 +20,6 @@ cp -f $SRC_PATH/LICENSE_MIT.TXT $TARGET_INSTALL_ROOT/
 
 mkdir -p $BIN_PATH/Release
 
-cp -f $SRC_PATH/build/release/azslc $BIN_PATH/Release/
+cp -f $SRC_PATH/build/Release/azslc $BIN_PATH/Release/
 
 exit 0


### PR DESCRIPTION
…cutable in the package.

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>