### PR TITLE
Updates to pull_and_build_from_git workflow

### DIFF
--- a/Scripts/extras/pull_and_build_from_git.py
+++ b/Scripts/extras/pull_and_build_from_git.py
@@ -1135,8 +1135,8 @@ if __name__ == '__main__':
                             help='The platform to build the package for.',
                             required=True)
         parser.add_argument('--package-root',
-                            help="The root path where to install the built packages to.",
-                            required=True)
+                            help="The root path where to install the built packages to. This defaults to the {base_path}/temp. ",
+                            required=False)
         parser.add_argument('--cmake-path',
                             help='Path to where cmake is installed. Defaults to the system installed one.',
                             default='')
@@ -1156,6 +1156,9 @@ if __name__ == '__main__':
                             default=False)
 
         parsed_args = parser.parse_args(sys.argv[1:])
+
+        # If package_root is not supplied, default to {base_path}/temp
+        package_root = parsed_args.package_root or f'{parsed_args.base_path}/temp'
 
         cmake_path = validate_cmake(f"{parsed_args.cmake_path}/cmake" if parsed_args.cmake_path else "cmake")
 

--- a/Scripts/extras/pull_and_build_from_git.py
+++ b/Scripts/extras/pull_and_build_from_git.py
@@ -1061,6 +1061,9 @@ def prepare_build(platform_name, base_folder, build_folder, package_root_folder,
     try:
         eligible_platforms = build_config["Platforms"][platform.system()]
         target_platform_config = eligible_platforms[platform_name]
+        # Check if the target platform is an alias to another platform from the current eligible_platforms
+        if isinstance(target_platform_config, str) and target_platform_config[0] == '@':
+            target_platform_config = eligible_platforms[target_platform_config[1:]]
     except KeyError as e:
         raise BuildError(f"Invalid build config : {str(e)}")
 

--- a/Scripts/extras/pull_and_build_from_git.py
+++ b/Scripts/extras/pull_and_build_from_git.py
@@ -1161,7 +1161,7 @@ if __name__ == '__main__':
         parsed_args = parser.parse_args(sys.argv[1:])
 
         # If package_root is not supplied, default to {base_path}/temp
-        package_root = parsed_args.package_root or f'{parsed_args.base_path}/temp'
+        resolved_package_root = parsed_args.package_root or f'{parsed_args.base_path}/temp'
 
         cmake_path = validate_cmake(f"{parsed_args.cmake_path}/cmake" if parsed_args.cmake_path else "cmake")
 
@@ -1169,7 +1169,7 @@ if __name__ == '__main__':
         build_info = prepare_build(platform_name=parsed_args.platform_name,
                                    base_folder=parsed_args.base_path,
                                    build_folder=parsed_args.build_path,
-                                   package_root_folder=parsed_args.package_root,
+                                   package_root_folder=resolved_package_root,
                                    cmake_command=cmake_path,
                                    build_config_file=parsed_args.build_config_file,
                                    clean=parsed_args.clean,


### PR DESCRIPTION
**Replace 'git stash' with 'git status' + 'git restore'**

The original method to attempt to restore a branch to its pristine state was 'git stash'. This is not the ideal approach and does not work when the cloned repository has sub-modules.

The approach has been updated to use a combination of ```git status``` and ```git restore```
1. Use ```git status``` to determine if anything has been modified
2. Use ```git restore``` with the --recurse-submodule option to do the proper restore to the pristine state

**Default --package-root to {base_path}/temp**
Since its recommended to set the source and build paths to a temporary folder anyways, updated the arguments so that '--package-root' now defaults to the ```base_path``` (required) argument + the ```temp``` sub-folder which is created automatically anyways.

**Support target platform aliasing**
Support to supply '@<target_platform_name>' to reference an existing <target_platform_name> in the build_config.json files. This will support things like the linux arm64 update since the majority of cases the settings will be the same for arm64 as it is for x86_64 (default).

