### PR TITLE
Script updates for zlib on the linux aarch64 platform

### DIFF
--- a/package-system/zlib/build_config.json
+++ b/package-system/zlib/build_config.json
@@ -58,7 +58,8 @@
                 "custom_install_cmd": [
                     "./install_zlib_linux.sh"
                 ]
-            }
+            },
+	    "Linux-aarch64": "@Linux"
         }
     }
 }

--- a/package-system/zlib/build_zlib_linux.sh
+++ b/package-system/zlib/build_zlib_linux.sh
@@ -11,10 +11,10 @@
 
 # Building zlib on ubuntu requires the following packages
 REQUIRED_DEV_PACKAGES="cmake ninja-build gcc"
-ALL_PACKAGES=`apt list | grep installed  2>/dev/null`
+ALL_PACKAGES=$(apt list | grep installed  2>/dev/null)
 for req_package in $REQUIRED_DEV_PACKAGES
 do
-    PACKAGE_COUNT=`echo $ALL_PACKAGES | grep $req_package | wc -l`
+    PACKAGE_COUNT=$(echo $ALL_PACKAGES | grep $req_package | wc -l)
     if [[ $PACKAGE_COUNT -eq 0 ]]; then
         echo "Missing required package '${req_package}'. Install this package and try again."
         exit 1

--- a/package-system/zlib/build_zlib_linux.sh
+++ b/package-system/zlib/build_zlib_linux.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
@@ -5,6 +7,21 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #
+
+
+# Building zlib on ubuntu requires the following packages
+REQUIRED_DEV_PACKAGES="cmake ninja-build gcc"
+ALL_PACKAGES=`apt list | grep installed  2>/dev/null`
+for req_package in $REQUIRED_DEV_PACKAGES
+do
+    PACKAGE_COUNT=`echo $ALL_PACKAGES | grep $req_package | wc -l`
+    if [[ $PACKAGE_COUNT -eq 0 ]]; then
+        echo "Missing required package '${req_package}'. Install this package and try again."
+        exit 1
+    fi
+done
+
+
 
 cmake -S temp/src -B temp/build \
      -G Ninja \

--- a/package_build_list_host_linux-aarch64.json
+++ b/package_build_list_host_linux-aarch64.json
@@ -1,0 +1,12 @@
+{
+    "comment" : "This is the list that applies to linux arm64 hosts",
+    "comment2" : "build_from_source is package name --> build script to call with params",
+    "comment3" : "build_from_folder is package name --> folder containing built image of package",
+    "comment4" : "Note:  Build from source occurs before build_from_folder",
+    "build_from_source": {
+        "zlib-1.2.11-rev5-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Linux-aarch64 --clean"
+    },
+    "build_from_folder": {
+        "zlib-1.2.11-rev5-linux-aarch64": "package-system/zlib/temp/zlib-linux-aarch64"
+    }
+}


### PR DESCRIPTION
Script updates for zlib on Linux aarch64 (ARM64)

3P packages built on Ubuntu 20.04 ARM64 with the following command

```
python3 ../3p-package-scripts/o3de_package_scripts/build_package.py --search_path . zlib-1.2.11-rev5-linux-aarch64
```

ZLib package files uploaded to dev S3 bucket:

```
zlib-1.2.11-rev5-linux-aarch64.tar.xz
zlib-1.2.11-rev5-linux-aarch64.tar.xz.SHA256SUMS
zlib-1.2.11-rev5-linux-aarch64.tar.xz.content.SHA256SUMS
zlib-1.2.11-rev5-linux-aarch64.PackageInfo.json
```
Package Hash
```
63d4ad0367c44191b946c51af713da2bd1aa497a2022b7ef58be0d01cd4d361e
```


Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>