### PR TITLE
Script updates for png-1.6.37 on Linux aarch64 (ARM64)

### DIFF
--- a/package-system/libpng/build_config.json
+++ b/package-system/libpng/build_config.json
@@ -103,7 +103,7 @@
                 ],
                 "cmake_generate_args_release": [
                     "-G",
-                    "Unix\\ Makefiles",
+                    "Ninja",
                     "-DCMAKE_BUILD_TYPE=Release"
                 ],
                 "custom_test_cmd": [
@@ -116,7 +116,7 @@
                 ],
                 "cmake_generate_args_release": [
                     "-G",
-                    "Unix\\ Makefiles",
+                    "Ninja",
                     "-DCMAKE_BUILD_TYPE=Release"
                 ],
                 "custom_test_cmd": [

--- a/package-system/libpng/build_config.json
+++ b/package-system/libpng/build_config.json
@@ -109,6 +109,19 @@
                 "custom_test_cmd": [
                     "./test_png_linux.sh"
                 ]
+            },
+            "Linux-aarch64": {
+                "depends_on_packages" :[
+                    ["zlib-1.2.11-rev5-linux-aarch64", "ce9d1ed2883d77ffc69c7982c078595c1f89ca55ec19d89fe7e6beb05f774775", ""]
+                ],
+                "cmake_generate_args_release": [
+                    "-G",
+                    "Unix\\ Makefiles",
+                    "-DCMAKE_BUILD_TYPE=Release"
+                ],
+                "custom_test_cmd": [
+                    "./test_png_linux.sh"
+                ]
             }
         }
     }

--- a/package_build_list_host_linux-aarch64.json
+++ b/package_build_list_host_linux-aarch64.json
@@ -4,9 +4,11 @@
     "comment3" : "build_from_folder is package name --> folder containing built image of package",
     "comment4" : "Note:  Build from source occurs before build_from_folder",
     "build_from_source": {
+        "png-1.6.37-rev2-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/libpng --platform-name Linux-aarch64 --clean",
         "zlib-1.2.11-rev5-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Linux-aarch64 --clean"
     },
     "build_from_folder": {
+        "png-1.6.37-rev2-linux-aarch64":  "package-system/libpng/temp/png-linux-aarch64",
         "zlib-1.2.11-rev5-linux-aarch64": "package-system/zlib/temp/zlib-linux-aarch64"
     }
 }


### PR DESCRIPTION
**Build Command**
```
python3 ../3p-package-scripts/o3de_package_scripts/build_package.py --search_path .  png-1.6.37-rev2-linux-aarch64 
```

**Build output**
```
Creating/Updating package: png-1.6.37-rev2-linux-aarch64
    Adding files to: "./packages/temp/temp_package_png-1.6.37-rev2-linux-aarch64"
    Created: ./packages/png-1.6.37-rev2-linux-aarch64.tar.xz
    Created: ./packages/png-1.6.37-rev2-linux-aarch64.tar.xz.SHA256SUMS
    Created: ./packages/png-1.6.37-rev2-linux-aarch64.tar.xz.content.SHA256SUMS
    Created: ./packages/png-1.6.37-rev2-linux-aarch64.PackageInfo.json
    - Validating package: png-1.6.37-rev2-linux-aarch64 in folder ./packages....
    Package Hash: fcf646c1b1b4163000efdb56d7c8f086b6ce0a520da5c8d3ffce4e1329ae798a *png-1.6.37-rev2-linux-aarch64.tar.xz

```

**Upload output**
```
Using bucket: ly-dev-3p-packages
Package: png-1.6.37-rev2-linux-aarch64 ...
    - Validating package: png-1.6.37-rev2-linux-aarch64 in folder ./packages....
    - Uploading png-1.6.37-rev2-linux-aarch64.tar.xz...
    - Uploading png-1.6.37-rev2-linux-aarch64.tar.xz.SHA256SUMS...
    - Uploading png-1.6.37-rev2-linux-aarch64.tar.xz.content.SHA256SUMS...
    - Uploading png-1.6.37-rev2-linux-aarch64.PackageInfo.json...
    - Uploaded package png-1.6.37-rev2-linux-aarch64.
```

