### PR TITLE
Added vulkan-validationlayers for Linux

### DIFF
--- a/package-system/vulkan-validationlayers/Findvulkan-validationlayers.cmake
+++ b/package-system/vulkan-validationlayers/Findvulkan-validationlayers.cmake
@@ -15,7 +15,7 @@ endif()
 
 set(PATH_TO_DLL ${CMAKE_CURRENT_LIST_DIR}/vulkan-validationlayers/lib/release)
 
-set(_DLL_NAME ${PATH_TO_DLL}/VkLayer_khronos_validation${CMAKE_SHARED_LIBRARY_SUFFIX})
+set(_DLL_NAME ${PATH_TO_DLL}/${CMAKE_SHARED_LIBRARY_PREFIX}VkLayer_khronos_validation${CMAKE_SHARED_LIBRARY_SUFFIX})
 set(${MY_NAME}_RUNTIME_JSON_DEPENDENCIES ${PATH_TO_DLL}/VkLayer_khronos_validation.json)
 
 add_library(${TARGET_WITH_NAMESPACE} INTERFACE IMPORTED GLOBAL) 

--- a/package-system/vulkan-validationlayers/build_config.json
+++ b/package-system/vulkan-validationlayers/build_config.json
@@ -21,6 +21,19 @@
                     "install_vulkan_validation_windows.cmd"
                 ]
             }
+        },
+        "Linux":{
+            "Linux":{
+                "cmake_find_source": "Findvulkan-validationlayers.cmake",
+                "cmake_find_target": "Findvulkan-validationlayers.cmake",
+                "custom_build_cmd": [
+                  "./build_vulkan_validation_linux.sh"
+                ],
+                "custom_install_cmd": [
+                  "./install_vulkan_validation_linux.sh"
+                ]
+            },
+            "Linux-aarch64": "@Linux"
         }
     }
 }

--- a/package-system/vulkan-validationlayers/build_vulkan_validation_linux.sh
+++ b/package-system/vulkan-validationlayers/build_vulkan_validation_linux.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+
+SRC_DIR=$TEMP_FOLDER/src
+BUILD_DIR=$TEMP_FOLDER/build
+TMP_RELEASE_DIR=$BUILD_DIR/install/lib/release
+
+$PYTHON_BINARY $SRC_DIR/scripts/update_deps.py --dir $SRC_DIR/external --arch x64 --config release
+cmake -G "Ninja Multi-Config" -C $SRC_DIR/external/helper.cmake -S $SRC_DIR -B $BUILD_DIR
+cmake --build $BUILD_DIR --config Release --target clean
+cmake --build $BUILD_DIR --config Release
+
+mkdir -p $TMP_RELEASE_DIR
+mv $BUILD_DIR/layers/Release/* $TMP_RELEASE_DIR
+
+exit 0

--- a/package-system/vulkan-validationlayers/install_vulkan_validation_linux.sh
+++ b/package-system/vulkan-validationlayers/install_vulkan_validation_linux.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+BUILD_DIR=$TEMP_FOLDER/build
+TMP_RELEASE_DIR=$BUILD_DIR/install/lib/release
+
+OUT_RELEASE=$TARGET_INSTALL_ROOT/lib/release
+
+mkdir -p $OUT_RELEASE
+
+cp $TMP_RELEASE_DIR/* $OUT_RELEASE
+if [ $? -ne 0 ]; then
+    echo Unable to copy $TMP_RELEASE_DIR to $OUT_RELEASE
+    exit 1
+fi
+
+exit 0

--- a/package_build_list_host_linux.json
+++ b/package_build_list_host_linux.json
@@ -40,7 +40,7 @@
         "zlib-1.2.11-rev5-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Linux --package-root ../../package-system --clean",
         "lz4-1.9.3-vcpkg-rev4-linux": "package-system/lz4/build_package_image.py --platform-name linux",
         "expat-2.4.2-rev2-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/expat --platform-name Linux --package-root ../../package-system/expat/temp --clean",
-        "vulkan-validationlayers-1.2.198-rev1-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/vulkan-validationlayers --platform-name Linux --package-root ../../package-system --clean"
+        "vulkan-validationlayers-1.2.198-rev1-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/vulkan-validationlayers --platform-name Linux --package-root ../../package-system/vulkan-validationlayers/temp --clean"
     },
     "build_from_folder": {
         "assimp-5.2.5-rev1-linux": "package-system/assimp-linux",
@@ -81,6 +81,6 @@
         "zlib-1.2.11-rev5-linux": "package-system/zlib-linux",
         "lz4-1.9.3-vcpkg-rev4-linux": "package-system/lz4-linux",
         "expat-2.4.2-rev2-linux": "package-system/expat/temp/expat-linux",
-        "vulkan-validationlayers-1.2.198-rev1-linux": "package-system/vulkan-validationlayers-linux"
+        "vulkan-validationlayers-1.2.198-rev1-linux": "package-system/vulkan-validationlayers/temp/vulkan-validationlayers-linux"
     }
 }

--- a/package_build_list_host_linux.json
+++ b/package_build_list_host_linux.json
@@ -39,7 +39,8 @@
         "qt-5.15.2-rev8-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Qt --platform-name Linux --package-root ../../package-system/Qt/temp --clean",
         "zlib-1.2.11-rev5-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Linux --package-root ../../package-system --clean",
         "lz4-1.9.3-vcpkg-rev4-linux": "package-system/lz4/build_package_image.py --platform-name linux",
-        "expat-2.4.2-rev2-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/expat --platform-name Linux --package-root ../../package-system/expat/temp --clean"
+        "expat-2.4.2-rev2-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/expat --platform-name Linux --package-root ../../package-system/expat/temp --clean",
+        "vulkan-validationlayers-1.2.198-rev1-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/vulkan-validationlayers --platform-name Linux --package-root ../../package-system --clean"
     },
     "build_from_folder": {
         "assimp-5.2.5-rev1-linux": "package-system/assimp-linux",
@@ -79,6 +80,7 @@
         "qt-5.15.2-rev8-linux": "package-system/Qt/temp/qt-linux",
         "zlib-1.2.11-rev5-linux": "package-system/zlib-linux",
         "lz4-1.9.3-vcpkg-rev4-linux": "package-system/lz4-linux",
-        "expat-2.4.2-rev2-linux": "package-system/expat/temp/expat-linux"
+        "expat-2.4.2-rev2-linux": "package-system/expat/temp/expat-linux",
+        "vulkan-validationlayers-1.2.198-rev1-linux": "package-system/vulkan-validationlayers-linux"
     }
 }


### PR DESCRIPTION
Using the same package version as Windows: v1.2.198

To generate the package locally in a linux machine: $ python3 ../3p-package-scripts/o3de_package_scripts/build_package.py \
  --search_path . vulkan-validationlayers-1.2.198-rev1-linux

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>