### PR TITLE
build sqlite lib linking against msvcrt.dll

### DIFF
--- a/package-system/sqlite/build_windows.cmd
+++ b/package-system/sqlite/build_windows.cmd
@@ -20,7 +20,7 @@ ECHO path as tcl is required to build for windows
 cd %BLD_PATH%
 
 REM Build the release library
-call nmake /f ..\src\Makefile.msc TOP=..\src libsqlite3.lib DEBUG=0
+call nmake /f ..\src\Makefile.msc TOP=..\src libsqlite3.lib DEBUG=0 USE_CRT_DLL=1
 IF %ERRORLEVEL% NEQ 0 (
     ECHO "nmake for debug Command Failed"
     exit /b 1


### PR DESCRIPTION
Fix [7326](https://github.com/o3de/o3de/issues/7326),  [7188](https://github.com/o3de/o3de/issues/7188).
Link sqlite lib agains msvcrt, not libcmt, to remove the following warning: 
```
LINK : warning LNK4098: defaultlib 'LIBCMT' conflicts with use of other libs; use /NODEFAULTLIB:library
```

Signed-off-by: Jackie9527 <80555200+Jackie9527@users.noreply.github.com>