### PR TITLE
Script updates for vulkan-validationlayers-1.2.198 on Linux aarch64 (ARM64)

### DIFF
--- a/package-system/vulkan-validationlayers/Dockerfile.linux
+++ b/package-system/vulkan-validationlayers/Dockerfile.linux
@@ -1,0 +1,59 @@
+
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+# This docker file uses ubuntu 20.04 as the base image so that the AWS Native C++ libraries will use OpenSSL 3 as the base
+# for its dependencies
+#
+
+FROM public.ecr.aws/ubuntu/ubuntu:20.04_stable
+ 
+WORKDIR /data/workspace
+
+ARG DOCKER_BUILD_SCRIPT
+
+# Initilize apt cache
+RUN apt-get clean && apt-get update
+
+# Setup time zone and locale data (necessary for SSL and HTTPS packages)
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata locales keyboard-configuration gpg wget
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+
+# Setup to use a more recent version of cmake (required) from kitware (3.22) than whats available from 20.04 by default
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
+    apt-get update
+
+# Install the development packages needed to build Qt from source
+RUN apt-get install -y build-essential \
+                       pkg-config \
+                       ninja-build \
+                       git \
+                       cmake \
+                       libxcb1-dev \
+                       python3-distutils \
+                       libx11-xcb-dev \
+                       libxkbcommon-dev \
+                       libwayland-dev \
+                       libxrandr-dev \
+                       libegl1-mesa-dev
+
+
+RUN apt upgrade -y
+
+# Prepare a target folder within the container to install the build artifacts tp
+RUN mkdir -p /data/workspace/build
+
+ARG CACHEBUST=1
+
+# Copy the build script specific to this Docker script in order to execute the build
+COPY $DOCKER_BUILD_SCRIPT /data/workspace/
+

--- a/package-system/vulkan-validationlayers/build_config.json
+++ b/package-system/vulkan-validationlayers/build_config.json
@@ -27,7 +27,7 @@
                 "cmake_find_source": "Findvulkan-validationlayers.cmake",
                 "cmake_find_target": "Findvulkan-validationlayers.cmake",
                 "custom_build_cmd": [
-                  "./build_vulkan_validation_linux.sh"
+                  "./build_linux.sh"
                 ],
                 "custom_install_cmd": [
                   "./install_vulkan_validation_linux.sh"

--- a/package-system/vulkan-validationlayers/build_linux.sh
+++ b/package-system/vulkan-validationlayers/build_linux.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+# TEMP_FOLDER and TARGET_INSTALL_ROOT get set from the pull_and_build_from_git.py script
+
+
+DOCKER_BUILD_SCRIPT=build_vulkan_validation_linux.sh
+DOCKER_IMAGE_NAME=vulkan_validation_layer_3p
+
+
+# Make sure docker is installed
+DOCKER_VERSION=$(docker --version)
+if [ $? -ne 0 ]
+then
+    echo "Required package docker is not installed"
+    echo "Follow instructions on https://docs.docker.com/engine/install/ubuntu/ to install docker properly"
+    exit 1
+fi
+echo "Detected Docker Version $DOCKER_VERSION"
+
+
+# Copy the custom build script to docker context folder
+cp $DOCKER_BUILD_SCRIPT temp/
+
+pushd temp
+
+# Build the Docker Image
+echo "Creating docker image  ${DOCKER_IMAGE_NAME}"
+docker build --build-arg DOCKER_BUILD_SCRIPT=${DOCKER_BUILD_SCRIPT} -f ../Dockerfile.linux -t ${DOCKER_IMAGE_NAME}:latest . 
+if [ $? -ne 0 ]
+then
+    echo "Error occurred creating Docker image ${DOCKER_IMAGE_NAME}:latest." 
+    exit 1
+fi
+
+
+# Capture the Docker Image ID
+IMAGE_ID=$(docker images -q ${DOCKER_IMAGE_NAME}:latest)
+if [ -z $IMAGE_ID ]
+then
+    echo "Error: Cannot find Image ID for ${DOCKER_IMAGE_NAME}"
+    exit 1
+fi
+
+
+# Run the Docker Image
+echo "Running build script in the docker image ${DOCKER_IMAGE_NAME}"
+docker run -v $TEMP_FOLDER/src:/data/workspace/src --tty ${DOCKER_IMAGE_NAME}:latest /data/workspace/$DOCKER_BUILD_SCRIPT
+if [ $? -ne 0 ]
+then
+    echo Failed to build from docker image ${DOCKER_IMAGE_NAME}:latest
+    exit 1
+fi
+
+
+# Capture the container ID
+echo "Capturing the Container ID"
+CONTAINER_ID=$(docker container ls -l -q --filter "ancestor=${DOCKER_IMAGE_NAME}:latest")
+if [ -z $CONTAINER_ID ]
+then
+    echo "Error: Cannot find Container ID for Image ${DOCKER_IMAGE_NAME}"
+    exit 1
+fi
+
+
+# Copy the build artifacts from the Docker Container
+echo "Copying the built contents from the docker container for image ${DOCKER_IMAGE_NAME}"
+
+mkdir -p build
+docker  cp --quiet $CONTAINER_ID:/data/workspace/build/. build  
+if [ $? -ne 0 ]
+then
+    echo "Error occurred copying build artifacts from Docker image ${DOCKER_IMAGE_NAME}:latest." 
+    exit 1
+fi
+
+
+# Clean up the docker image and container
+echo "Cleaning up container"
+docker container rm $CONTAINER_ID || (echo "Warning: unable to clean up container for image ${DOCKER_IMAGE_NAME}")
+
+echo "Cleaning up image"
+docker rmi --force $IMAGE_ID  || (echo "Warning: unable to clean up image ${DOCKER_IMAGE_NAME}")
+
+popd
+
+exit 0
+

--- a/package-system/vulkan-validationlayers/build_vulkan_validation_linux.sh
+++ b/package-system/vulkan-validationlayers/build_vulkan_validation_linux.sh
@@ -5,15 +5,38 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-
+TEMP_FOLDER=/data/workspace
 SRC_DIR=$TEMP_FOLDER/src
 BUILD_DIR=$TEMP_FOLDER/build
 TMP_RELEASE_DIR=$BUILD_DIR/install/lib/release
 
-$PYTHON_BINARY $SRC_DIR/scripts/update_deps.py --dir $SRC_DIR/external --arch x64 --config release
-cmake -G "Ninja Multi-Config" -C $SRC_DIR/external/helper.cmake -S $SRC_DIR -B $BUILD_DIR
+python3 $SRC_DIR/scripts/update_deps.py --dir $TEMP_FOLDER/external --arch x64 --config release
+if [ $? -ne 0 ]
+then
+    echo "Error configuring build environment"
+    exit 1
+fi
+
+cmake -G "Ninja Multi-Config" -C $TEMP_FOLDER/external/helper.cmake -S $SRC_DIR -B $BUILD_DIR
+if [ $? -ne 0 ]
+then
+    echo "Error generating cmake project"
+    exit 1
+fi
+
 cmake --build $BUILD_DIR --config Release --target clean
+if [ $? -ne 0 ]
+then
+    echo "Error cleaning project"
+    exit 1
+fi
+
 cmake --build $BUILD_DIR --config Release
+if [ $? -ne 0 ]
+then
+    echo "Error building project"
+    exit 1
+fi
 
 mkdir -p $TMP_RELEASE_DIR
 mv $BUILD_DIR/layers/Release/* $TMP_RELEASE_DIR

--- a/package_build_list_host_linux-aarch64.json
+++ b/package_build_list_host_linux-aarch64.json
@@ -35,6 +35,7 @@
         "SQLite-3.37.2-rev1-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/sqlite --platform-name Linux-aarch64 --clean",
         "tiff-4.2.0.15-rev3-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/tiff --platform-name Linux-aarch64 --clean",
         "v-hacd-2.3-1a49edf-rev1-linux-aarch64": "package-system/v-hacd/build_package_image.py --platform-name linux-aarch64",
+	"vulkan-validationlayers-1.2.198-rev1-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/vulkan-validationlayers --platform-name Linux-aarch64 --clean",
         "zlib-1.2.11-rev5-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Linux-aarch64 --clean"
     },
     "build_from_folder": {
@@ -69,6 +70,7 @@
         "SQLite-3.37.2-rev1-linux-aarch64": "package-system/sqlite/temp/SQLite-linux-aarch64",
         "tiff-4.2.0.15-rev3-linux-aarch64": "package-system/tiff/temp/tiff-linux-aarch64",
         "v-hacd-2.3-1a49edf-rev1-linux-aarch64": "package-system/v-hacd-linux-aarch64",
+ 	"vulkan-validationlayers-1.2.198-rev1-linux-aarch64": "package-system/vulkan-validationlayers/temp/vulkan-validationlayers-linux-aarch64",
         "zlib-1.2.11-rev5-linux-aarch64": "package-system/zlib/temp/zlib-linux-aarch64"
     }
 }


### PR DESCRIPTION
Dockerize the linux build for vulkan validation layers and support arm64 builds

**Build Command**
```
python3 ../3p-package-scripts/o3de_package_scripts/build_package.py --search_path . assimp-5.1.6-rev2-linux-aarch64
```

**Build output**
```
Creating/Updating package: vulkan-validationlayers-1.2.198-rev1-linux-aarch64
    Adding files to: "./packages/temp/temp_package_vulkan-validationlayers-1.2.198-rev1-linux-aarch64"
    Created: ./packages/vulkan-validationlayers-1.2.198-rev1-linux-aarch64.tar.xz
    Created: ./packages/vulkan-validationlayers-1.2.198-rev1-linux-aarch64.tar.xz.SHA256SUMS
    Created: ./packages/vulkan-validationlayers-1.2.198-rev1-linux-aarch64.tar.xz.content.SHA256SUMS
    Created: ./packages/vulkan-validationlayers-1.2.198-rev1-linux-aarch64.PackageInfo.json
    - Validating package: vulkan-validationlayers-1.2.198-rev1-linux-aarch64 in folder ./packages....
    Package Hash: e67a15a95e14397ccdffd70d17f61079e5720fea22b0d21e135497312419a23f *vulkan-validationlayers-1.2.198-rev1-linux-aarch64.tar.xz
```

**Upload output**
```
Using bucket: ly-dev-3p-packages
Package: vulkan-validationlayers-1.2.198-rev1-linux-aarch64 ...
    - Validating package: vulkan-validationlayers-1.2.198-rev1-linux-aarch64 in folder ./packages....
    - Uploading vulkan-validationlayers-1.2.198-rev1-linux-aarch64.tar.xz...
    - Uploading vulkan-validationlayers-1.2.198-rev1-linux-aarch64.tar.xz.SHA256SUMS...
    - Uploading vulkan-validationlayers-1.2.198-rev1-linux-aarch64.tar.xz.content.SHA256SUMS...
    - Uploading vulkan-validationlayers-1.2.198-rev1-linux-aarch64.PackageInfo.json...
    - Uploaded package vulkan-validationlayers-1.2.198-rev1-linux-aarch64.
```
Log of the build: [build_vulkan.log](https://github.com/o3de/3p-package-source/files/10816313/build_vulkan.log)

