### PR TITLE
Fixes for the openimageio package on aarch64

### DIFF
--- a/package-system/openimageio-opencolorio/build_openimageio.py
+++ b/package-system/openimageio-opencolorio/build_openimageio.py
@@ -212,7 +212,7 @@ if args.platform not in dependencies.keys():
 # script, the test at the end which attempts to import the built python bindings
 # will fail, so we need to make sure the same version of python is running
 # this build script.
-expected_python_version = '3.10.5'
+expected_python_version = '3.10'
 if not sys.version.startswith(expected_python_version):
     print(f"Error: Build script needs to be run with python version {expected_python_version}, current version is {sys.version}")
     sys.exit(1)

--- a/package-system/openimageio-opencolorio/distribution/FindOpenImageIO.cmake
+++ b/package-system/openimageio-opencolorio/distribution/FindOpenImageIO.cmake
@@ -154,7 +154,12 @@ endif()
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     set(OpenImageIOPythonBindings ${OpenImageIO_LIB_DIR}/python3.10/site-packages/OpenImageIO.cp310-win_amd64.pyd)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    set(OpenImageIOPythonBindings ${OpenImageIO_LIB_DIR}/python3.10/site-packages/OpenImageIO.cpython-310-x86_64-linux-gnu.so)
+
+    if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+        set(OpenImageIOPythonBindings ${OpenImageIO_LIB_DIR}/python3.10/site-packages/OpenImageIO.cpython-310-aarch64-linux-gnu.so)
+    else()
+        set(OpenImageIOPythonBindings ${OpenImageIO_LIB_DIR}/python3.10/site-packages/OpenImageIO.cpython-310-x86_64-linux-gnu.so)
+    endif()
     
 else() # Darwin
     set(OpenImageIOPythonBindings ${OpenImageIO_LIB_DIR}/python3.10/site-packages/OpenImageIO.cpython-310-darwin.so)


### PR DESCRIPTION
- Reduce the expected python version precision to just major + minor version (X.Y)
- Select the correct shared library for aarch64 vs x86_64 on Linux

[openimageio_build.log](https://github.com/o3de/3p-package-source/files/10927567/openimageio_build.log)
