### PR TITLE
Updated AWSGameLiftServerSDK 5.0.0 to build on linux

### DIFF
--- a/package_build_list_host_linux-aarch64.json
+++ b/package_build_list_host_linux-aarch64.json
@@ -6,7 +6,7 @@
     "build_from_source": {
         "assimp-5.2.5-rev1-linux-aarch64":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Linux-aarch64 --clean",
         "astc-encoder-3.2-rev3-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/astc-encoder --platform-name Linux-aarch64 --clean",
-        "AWSGameLiftServerSDK-3.4.2-rev1-linux-aarch64": "package-system/AWSGameLiftServerSDK/build_package_image.py --platform-name linux-aarch64",
+        "AWSGameLiftServerSDK-5.0.0-rev1-linux-aarch64": "package-system/AWSGameLiftServerSDK/build_package_image.py --platform-name linux-aarch64",
         "AwsIotDeviceSdkCpp-1.15.2-rev1-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AwsIotDeviceSdkCpp --platform-name Linux-aarch64 --clean",
         "AWSNativeSDK-1.9.50-rev2-linux-openssl-1-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Linux-OpenSSL-1-aarch64 --clean",
         "AWSNativeSDK-1.9.50-rev2-linux-openssl-3-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Linux-OpenSSL-3-aarch64 --clean",
@@ -46,7 +46,7 @@
     "build_from_folder": {
         "assimp-5.2.5-rev1-linux-aarch64": "package-system/assimp/temp/assimp-linux-aarch64",
         "astc-encoder-3.2-rev3-linux-aarch64": "package-system/astc-encoder/temp/astc-encoder-linux-aarch64",
-        "AWSGameLiftServerSDK-3.4.2-rev1-linux-aarch64": "package-system/AWSGameLiftServerSDK-linux-aarch64",
+        "AWSGameLiftServerSDK-5.0.0-rev1-linux-aarch64": "package-system/AWSGameLiftServerSDK-linux-aarch64",
         "AwsIotDeviceSdkCpp-1.15.2-rev1-linux-aarch64": "package-system/AwsIotDeviceSdkCpp/temp/AwsIotDeviceSdkCpp-linux-aarch64",
         "AWSNativeSDK-1.9.50-rev2-linux-openssl-1-aarch64": "package-system/AWSNativeSDK/temp/AWSNativeSDK-linux-openssl-1-aarch64",
         "AWSNativeSDK-1.9.50-rev2-linux-openssl-3-aarch64": "package-system/AWSNativeSDK/temp/AWSNativeSDK-linux-openssl-3-aarch64",

--- a/package_build_list_host_linux.json
+++ b/package_build_list_host_linux.json
@@ -5,7 +5,7 @@
     "comment4" : "Note:  Build from source occurs before build_from_folder",
     "build_from_source": {
         "assimp-5.2.5-rev1-linux":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Linux --package-root ../../package-system --clean",
-        "AWSGameLiftServerSDK-3.4.2-rev1-linux": "package-system/AWSGameLiftServerSDK/build_package_image.py --platform-name linux",
+        "AWSGameLiftServerSDK-5.0.0-rev1-linux": "package-system/AWSGameLiftServerSDK/build_package_image.py --platform-name linux",
         "AWSNativeSDK-1.9.50-rev2-linux-openssl-1": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Linux-OpenSSL-1 --package-root ../../package-system/AWSNativeSDK/temp --clean",
         "AWSNativeSDK-1.9.50-rev2-linux-openssl-3": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Linux-OpenSSL-3 --package-root ../../package-system/AWSNativeSDK/temp --clean",
         "cityhash-1.1-rev1-linux":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/cityhash --platform-name Linux --clean",
@@ -46,7 +46,7 @@
     },
     "build_from_folder": {
         "assimp-5.2.5-rev1-linux": "package-system/assimp-linux",
-        "AWSGameLiftServerSDK-3.4.2-rev1-linux": "package-system/AWSGameLiftServerSDK-linux",
+        "AWSGameLiftServerSDK-5.0.0-rev1-linux": "package-system/AWSGameLiftServerSDK-linux",
         "AWSNativeSDK-1.9.50-rev2-linux-openssl-1": "package-system/AWSNativeSDK/temp/AWSNativeSDK-linux-openssl-1",
         "AWSNativeSDK-1.9.50-rev2-linux-openssl-3": "package-system/AWSNativeSDK/temp/AWSNativeSDK-linux-openssl-3",
         "cityhash-1.1-rev1-linux": "package-system/cityhash/temp/cityhash-linux",


### PR DESCRIPTION
The `AWSGameLiftServerSDK` version `5.0.0` package only required a small change in order to build on linux (since we had already got it building on windows).

The server SDK tests are only built on linux, and they end up pulling down/building `googletest` as a dependency. There was actually a recent change that causes a compile error using `clang`:

https://github.com/google/googletest/issues/4206

However, I discovered in the gamelift README that `gcc` compiler is actually recommended over `clang`, and as mentioned in the bug, the Game Lift Server SDK builds fine with `gcc`, so the build script just needed to be modified to pass `gcc/g++` as the compiler instead.