### PR TITLE
Add cmake cache var to allow for use of system openssl

### DIFF
--- a/package-system/OpenSSL/FindOpenSSL.cmake.Linux.template
+++ b/package-system/OpenSSL/FindOpenSSL.cmake.Linux.template
@@ -1,0 +1,91 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(OPENSSL_O3DE_NAMESPACE "3rdParty::OpenSSL")
+if (TARGET $${OPENSSL_O3DE_NAMESPACE})
+    return()
+endif()
+
+set(SSL_TARGETNAME "OpenSSL::SSL")
+set(CRYPTO_TARGETNAME "OpenSSL::Crypto")
+
+if (LY_SYSTEM_PACKAGE_OpenSSL)
+
+    # We need to temporarily override the CMAKE_MODULE_PATH to force it to search in the system directories
+    set(CMAKE_MODULE_PATH "")
+    find_package(OpenSSL)
+    unset(CMAKE_MODULE_PATH)
+
+    if (NOT OpenSSL_FOUND)
+       message(FATAL_ERROR "Compiling on linux requires the development headers for OpenSSL.  Try using your package manager to install the OpenSSL development libraries following https://wiki.openssl.org/index.php/Libssl_API")
+    else()
+        # OpenSSL targets should be considered as provided by the system
+        set_target_properties(OpenSSL::SSL OpenSSL::Crypto PROPERTIES LY_SYSTEM_LIBRARY TRUE)
+    
+        # Alias the O3DE name to the official name
+        add_library(3rdParty::OpenSSL ALIAS OpenSSL::SSL)
+    endif()
+    
+else()
+
+    # we're trying to be a drop-in replacement for the FindOpenSSL.cmake that is shipped
+    # with CMake itself, so we set the same variables with the same uppercase for compatibility
+    # for questions about these variables, see https://cmake.org/cmake/help/latest/module/FindOpenSSL.html
+    set(OPENSSL_FOUND True)
+    set(OPENSSL_INCLUDE_DIR $${CMAKE_CURRENT_LIST_DIR}/OpenSSL/include)
+    # c-only packages can be released containing only Release executables
+    set(OPENSSL_LIBS_DIR $${CMAKE_CURRENT_LIST_DIR}/OpenSSL/lib)
+    set(OPENSSL_CRYPTO_LIBRARY $${OPENSSL_LIBS_DIR}/libcrypto$${CMAKE_STATIC_LIBRARY_SUFFIX})
+    set(OPENSSL_CRYPTO_LIBRARIES
+        $${OPENSSL_CRYPTO_LIBRARY}
+        ${CRYPTO_LIBRARY_DEPENDENCIES})
+    set(OPENSSL_SSL_LIBRARY $${OPENSSL_LIBS_DIR}/libssl$${CMAKE_STATIC_LIBRARY_SUFFIX})
+    set(OPENSSL_SSL_LIBRARIES 
+        $${OPENSSL_SSL_LIBRARY}
+        $${OPENSSL_CRYPTO_LIBRARIES})
+    set(OPENSSL_LIBRARIES $${OPENSSL_SSL_LIBRARIES})
+    set(OPENSSL_VERSION "${OPENSSL_VERSION_STRING}")
+    
+    add_library($${CRYPTO_TARGETNAME} STATIC IMPORTED GLOBAL)
+    set_target_properties($${CRYPTO_TARGETNAME} PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C")
+    set_target_properties($${CRYPTO_TARGETNAME} PROPERTIES IMPORTED_LOCATION "$${OPENSSL_CRYPTO_LIBRARY}")
+    
+    # anyone who links to the CRYPTO target also links to its dependencies:
+    target_link_libraries($${CRYPTO_TARGETNAME} INTERFACE ${CRYPTO_LIBRARY_DEPENDENCIES})
+    
+    add_library($${SSL_TARGETNAME} STATIC IMPORTED GLOBAL)
+    set_target_properties($${SSL_TARGETNAME} PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C")
+    set_target_properties($${SSL_TARGETNAME} PROPERTIES IMPORTED_LOCATION "$${OPENSSL_SSL_LIBRARY}")
+    
+    # anyone who links to the SSL target also links to CRYPTO since SSL depends on CRYPTO:
+    target_link_libraries($${SSL_TARGETNAME} INTERFACE $${CRYPTO_TARGETNAME})
+    
+    # cmake < 3.21 and visual studio < 16.10 don't properly implement SYSTEM includes
+    # so we use O3DEs patched implementation if it is available and fallback to default if not.
+    # this is futureproof so that when O3DE no longer needs to define this and CMake's system 
+    # works without fixes, O3DE can erase this implementation and this script will still function.
+    if (COMMAND ly_target_include_system_directories)
+        ly_target_include_system_directories(TARGET $${SSL_TARGETNAME} INTERFACE $${OPENSSL_INCLUDE_DIR})
+        ly_target_include_system_directories(TARGET $${CRYPTO_TARGETNAME} INTERFACE $${OPENSSL_INCLUDE_DIR})
+    else()
+        target_include_directories($${SSL_TARGETNAME} SYSTEM INTERFACE $${OPENSSL_INCLUDE_DIR})
+        target_include_directories($${CRYPTO_TARGETNAME} SYSTEM INTERFACE $${OPENSSL_INCLUDE_DIR})
+    endif()
+    
+    # alias the O3DE name to the official name:
+    add_library($${OPENSSL_O3DE_NAMESPACE} ALIAS $${SSL_TARGETNAME})
+    
+    # if we're not in O3DE, it's also extremely helpful to show a message to logs that indicate that this
+    # library was successfully picked up, as opposed to the system one.
+    # A good way to know if you're in O3DE or not is that O3DE sets various cache variables before 
+    # calling find_package, specifically, LY_VERSION_ENGINE_NAME is always set very early:
+    if (NOT LY_VERSION_ENGINE_NAME)
+        message(STATUS "Using O3DE's OpenSSL ($${OPENSSL_VERSION}) from $${CMAKE_CURRENT_LIST_DIR}")
+    endif()
+
+endif() # LY_SYSTEM_PACKAGE_OpenSSL

--- a/package-system/OpenSSL/build_config.json
+++ b/package-system/OpenSSL/build_config.json
@@ -10,7 +10,7 @@
    "Platforms":{
       "Linux":{
          "Linux":{
-            "cmake_find_template":"FindOpenSSL.cmake.template",
+            "cmake_find_template":"FindOpenSSL.cmake.Linux.template",
             "custom_build_cmd": [
                "./build-linux.sh",
                "openssl_1_1_1t",
@@ -31,7 +31,7 @@
             }
          },
          "Linux-aarch64":{
-            "cmake_find_template":"FindOpenSSL.cmake.template",
+            "cmake_find_template":"FindOpenSSL.cmake.Linux.template",
             "custom_build_cmd": [
                "./build-linux.sh",
                "openssl_1_1_1t",


### PR DESCRIPTION
See https://github.com/o3de/o3de/issues/16375 and https://github.com/o3de/3p-package-source/pull/205

This one was a bit trickier than SQLite, since the custom FindOpenSSL.cmake module takes precedent over the prewritten find module that is provided by cmake since they have the same name. SQLite doesn't have this problem because the system SQLite find module is "FindSQLite3.cmake" as opposed to the O3DE find module "FindSQLite.cmake," so there is no name collision. I ran into the same problem with the Freetype library, so it's not limited to just OpenSSL.

To get around this I manually set and then unset CMAKE_MODULE_PATH to an empty string. This workaround works because normal cmake variables have priority over cmake cache variables, and since CMAKE_MODULE_PATH is empty, the system find module is picked up as a fallback. 

The better solution would probably be to rename each find module to follow the pattern "FindO3DE_OpenSSL.cmake" or something similar and then do "find_package(O3DE_OpenSSL)" so there is no name collision, but that would be a bit more invasive and we would need to make sure to coordinate the changes in both this repo and the main o3de repo. If there's an easier solution I'm missing let me know.