### PR TITLE
Packaging build automation fixes

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout 3P source repo
       uses: actions/checkout@v4
       with:
-        fetch-depth: 10
+        fetch-depth: 0
           
     - name: Get package and platform from JSON changes
       id: detect-platform
@@ -48,7 +48,7 @@ jobs:
             esac
 
             DIFF=$(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} --no-ext-diff --unified=0 \
-                        --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get oly the changes that can be built
+                        --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get only the changes that can be built
 
             if [[ $? -ne 0 ]]; then
               echo No valid build change found. Exiting with non-zero
@@ -121,6 +121,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: 3p-package-source
+        fetch-depth: 0
     
     - name: Checkout 3P scripts repo
       uses: actions/checkout@v4
@@ -154,25 +155,17 @@ jobs:
         restore-keys:
           ${{ matrix.package }}-${{ matrix.os }}
         
-    - name: Run build command (windows)
-      if: contains(matrix.package, 'windows')
+    - name: Run build command
+      if: ${{ !contains(matrix.package, 'aarch64') }}
       env:
         CMAKE_CXX_COMPILER_LAUNCHER: sccache
         CMAKE_C_COMPILER_LAUNCHER: sccache
         CMAKE_GENERATOR: Ninja # ccache/sccache cannot be used as the compiler launcher under cmake if the generator is MSBuild
       run: |
         python3 3p-package-scripts/o3de_package_scripts/build_package.py --search_path 3p-package-source ${{ matrix.package }}
-    
-    - name: Run build command (linux/mac)
-      if: contains(matrix.package, 'linux') && ${{ !contains(matrix.package, 'aarch64') }}
-      env:
-        CMAKE_CXX_COMPILER_LAUNCHER: sccache
-        CMAKE_C_COMPILER_LAUNCHER: sccache
-      run: |
-        python3 3p-package-scripts/o3de_package_scripts/build_package.py --search_path 3p-package-source ${{ matrix.package }}
-    
-    - name: Run build command (linux aarch64)
-      if: contains(matrix.package, 'linux') && contains(matrix.package, 'aarch64')
+
+    - name: Run build command (aarch64)
+      if: contains(matrix.package, 'aarch64')
       uses: uraimo/run-on-arch-action@v2.5.1
       with:
         arch: none

--- a/.github/workflows/promote-packages.yaml
+++ b/.github/workflows/promote-packages.yaml
@@ -31,6 +31,21 @@ jobs:
           commit: ${{github.event.pull_request.head.sha}}
           check_artifacts: true
           path: ${{ env.PACKAGE_PATH }}
+
+      - name: Check if package already exists in prod
+        env:
+          PROD_CDN: ${{ vars.PROD_CDN }} # Change this to compare on your own endpoint
+        run: |
+          find ${{ env.PACKAGE_PATH }} -type f | while read file; do
+            filename=$(basename "$file")
+            url="${{ env.PROD_CDN }}/${filename}"
+            if curl --head --silent --fail ${url}.tar.xz > /dev/null 2>&1; then
+              echo ${filename} already exists in prod. Check the rev in the json file to ensure it is incremented
+              exit 1
+            else
+              echo ${filename} does not exist in CDN, continuing...
+            fi
+           done
       
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/promote-packages.yaml
+++ b/.github/workflows/promote-packages.yaml
@@ -3,8 +3,17 @@
 name: Promote 3P Packages
 
 on:
-  # Allows you to run this workflow manually from the Actions tag
+  # Allows you to run this workflow manually from the Actions screen
   workflow_dispatch:
+    inputs:
+      PR-num:
+        type: string
+        required: false
+        description: PR number to pull from. Leave blank to pull from last successful run
+      Run-id-num:
+        type: string
+        required: false
+        description: Run id number (located in the build url) to pull from. Leave blank to pull from last successful run
 
   push:
     branches:
@@ -27,8 +36,8 @@ jobs:
         uses: dawidd6/action-download-artifact@v2.28.0
         with:
           workflow: build-pr-packages.yaml
-          workflow_conclusion: success
-          commit: ${{github.event.pull_request.head.sha}}
+          pr: ${{ inputs.PR-num }}
+          run_id: ${{ inputs.Run-id-num }}
           check_artifacts: true
           path: ${{ env.PACKAGE_PATH }}
 
@@ -39,7 +48,7 @@ jobs:
           find ${{ env.PACKAGE_PATH }} -type f | while read file; do
             filename=$(basename "$file")
             url="${{ env.PROD_CDN }}/${filename}"
-            if curl --head --silent --fail ${url}.tar.xz > /dev/null 2>&1; then
+            if curl --head --silent --fail ${url} > /dev/null 2>&1; then
               echo ${filename} already exists in prod. Check the rev in the json file to ensure it is incremented
               exit 1
             else


### PR DESCRIPTION
This fixes the following:
- Increases the fetch depth of the build job to 0 (get all history) in the event that the PR already has several commits ahead of it
- Simplifies the conditional logic to just look for "aarch64"

Also adds this feature:
- Allows the maintainer to promote to development S3 based on PR or Run ID, in the event the most recent run needs to be tested in O3DE AR first before it is merged in.
- Additional validation check for existing packages for the promotion automation

Testing method
- Ran in fork successfully

