### PR TITLE
Add 3 dots to git diff to catch only the changed files at head

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -47,13 +47,8 @@ jobs:
               ;;
             esac
 
-<<<<<<< HEAD
-            DIFF=$(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} --no-ext-diff --unified=0 \
-                        --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get oly the changes that can be built
-=======
             DIFF=$(git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --no-ext-diff --unified=0 \
-                        --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get only the changes that can be built
->>>>>>> 1829474 (Add 3 dots to git diff to catch only the changed files at head)
+                        --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get oly the changes that can be built
 
             if [[ $? -ne 0 ]]; then
               echo No valid build change found. Exiting with non-zero

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Get package and platform from JSON changes
       id: detect-platform
       run: |
-        CHANGED_FILES=$(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} --name-only)
+        CHANGED_FILES=$(git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --name-only)
         # Construct the package and os into a json string to be consumed by Github Actions runners
         JSON="{\"include\":["
         for FILE in $CHANGED_FILES; do
@@ -47,8 +47,13 @@ jobs:
               ;;
             esac
 
+<<<<<<< HEAD
             DIFF=$(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} --no-ext-diff --unified=0 \
                         --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get oly the changes that can be built
+=======
+            DIFF=$(git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --no-ext-diff --unified=0 \
+                        --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get only the changes that can be built
+>>>>>>> 1829474 (Add 3 dots to git diff to catch only the changed files at head)
 
             if [[ $? -ne 0 ]]; then
               echo No valid build change found. Exiting with non-zero


### PR DESCRIPTION
Fix a uncaught git diff command bug where the github actions pulls all changes up to main, instead of only the changes from the PR: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons

Tested in my fork