### PR TITLE
Update Github Action VM to Ubuntu 20.04 and pin GCC/Clang versions

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -23,26 +23,50 @@ jobs:
       packages: write
     steps:
       - name: Run build command (aarch64)
-        uses: uraimo/run-on-arch-action@v2
+        uses: uraimo/run-on-arch-action@v2.5.1
         with:
           env: |
-            GITHUB_WORKFLOW: ${{ github.workflow }}
-            SCCACHE_VER: 0.5.4
+            GITHUB_WORKFLOW: ${{ github.workflow }} # Sets the docker image to the name of the workflow
           arch: aarch64
-          distro: ubuntu_latest
+          distro: ubuntu20.04
           githubToken: ${{ github.token }}
           shell: /bin/bash
           install: |
+            ## Set variables. "env" not supported in install phase
+            export CLANG_VER=12
+            export GCC_VER=9
+            export SCCACHE_VER=0.5.4
+            export CMAKE_VER=3.27.6
+            ## Install build dependancies from apt
             apt-get update
-            apt-get install -y build-essential cmake curl git libssl-dev libffi-dev libbz2-dev libgdbm-compat-dev libgdbm-dev liblzma-dev libreadline-dev libtool \
-              ninja-build python3 python3-pip tcl8.6-dev tk8.6-dev texinfo software-properties-common
+            apt-get install -y build-essential curl git libssl-dev libffi-dev libbz2-dev libgdbm-compat-dev libgdbm-dev liblzma-dev libreadline-dev libtool \
+              ninja-build python3 python3-pip tcl8.6-dev tk8.6-dev texinfo software-properties-common wget
             python3 -m pip install boto3 certifi
-            curl -L 'https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-aarch64-unknown-linux-musl.tar.gz' \
-              | tar xzf - -O --wildcards '*/sccache' > '/usr/local/bin/sccache'
-            chmod +x '/usr/local/bin/sccache'
+            # Install Clang/GCC at specific version
+            apt-get install -y clang-${CLANG_VER} gcc-${GCC_VER} g++-${GCC_VER}
+            update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CLANG_VER} 10
+            update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VER} 10
+            update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VER} 10
+            update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VER} 10
+            ## Install sccache
+            wget -qO- "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-aarch64-unknown-linux-musl.tar.gz" \
+              | tar xzf - -O --wildcards '*/sccache' > '/usr/local/bin/sccache' \
+              && chmod +x '/usr/local/bin/sccache'
+            ## Install cmake  
+            wget -q "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-aarch64.sh" \
+              -O /tmp/cmake-install.sh \
+              && chmod u+x /tmp/cmake-install.sh \
+              && mkdir /opt/cmake-${CMAKE_VER} \
+              && /tmp/cmake-install.sh --skip-license --prefix=/opt/cmake-${CMAKE_VER} \
+              && rm /tmp/cmake-install.sh \
+              && ln -s /opt/cmake-${CMAKE_VER}/bin/* /usr/local/bin
+            rm -rf /var/lib/apt/lists/*
           run: |
             lsb_release -a
             uname -a
+            gcc --version
+            g++ --version
+            clang --version
             sccache --version
             cmake --version
             git --version

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout 3P source repo
       uses: actions/checkout@v4
       with:
-        fetch-depth: 10
+        fetch-depth: 0
           
     - name: Get package and platform from JSON changes
       id: detect-platform
@@ -48,7 +48,7 @@ jobs:
             esac
 
             DIFF=$(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} --no-ext-diff --unified=0 \
-                        --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get oly the changes that can be built
+                        --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get only the changes that can be built
 
             if [[ $? -ne 0 ]]; then
               echo No valid build change found. Exiting with non-zero
@@ -121,6 +121,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: 3p-package-source
+        fetch-depth: 0
     
     - name: Checkout 3P scripts repo
       uses: actions/checkout@v4
@@ -154,25 +155,17 @@ jobs:
         restore-keys:
           ${{ matrix.package }}-${{ matrix.os }}
         
-    - name: Run build command (windows)
-      if: contains(matrix.package, 'windows')
+    - name: Run build command
+      if: ${{ !contains(matrix.package, 'aarch64') }}
       env:
         CMAKE_CXX_COMPILER_LAUNCHER: sccache
         CMAKE_C_COMPILER_LAUNCHER: sccache
         CMAKE_GENERATOR: Ninja # ccache/sccache cannot be used as the compiler launcher under cmake if the generator is MSBuild
       run: |
         python3 3p-package-scripts/o3de_package_scripts/build_package.py --search_path 3p-package-source ${{ matrix.package }}
-    
-    - name: Run build command (linux/mac)
-      if: contains(matrix.package, 'linux') && ${{ !contains(matrix.package, 'aarch64') }}
-      env:
-        CMAKE_CXX_COMPILER_LAUNCHER: sccache
-        CMAKE_C_COMPILER_LAUNCHER: sccache
-      run: |
-        python3 3p-package-scripts/o3de_package_scripts/build_package.py --search_path 3p-package-source ${{ matrix.package }}
-    
-    - name: Run build command (linux aarch64)
-      if: contains(matrix.package, 'linux') && contains(matrix.package, 'aarch64')
+
+    - name: Run build command (aarch64)
+      if: contains(matrix.package, 'aarch64')
       uses: uraimo/run-on-arch-action@v2.5.1
       with:
         arch: none

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -34,7 +34,7 @@ jobs:
             PLATFORM=$(echo $FILE | sed -n 's/package_build_list_host_\(.*\).json/\1/p')
             case $PLATFORM in
             linux*)
-              OS_RUNNER="ubuntu-latest"
+              OS_RUNNER="ubuntu-20.04"
               ;;
             windows)
               OS_RUNNER="windows-2019"
@@ -145,6 +145,18 @@ jobs:
     - name: Update msbuild path
       if: runner.os == 'Windows'
       uses: ilammy/msvc-dev-cmd@v1.12.0
+    
+    - name: Install clang/gcc
+      if: runner.os == 'Linux'
+      env:
+        CLANG_VER: 12
+        GCC_VER: 9
+      run: |
+        sudo apt-get install -y clang-${{ env.CLANG_VER }} gcc-${{ env.GCC_VER }} g++-${{ env.GCC_VER }}
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.CLANG_VER }} 10
+        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{ env.CLANG_VER }} 10
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VER }} 10
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VER }} 10
 
     - name: Use sccache
       uses: hendrikmuhs/ccache-action@v1.2.10
@@ -170,7 +182,7 @@ jobs:
       with:
         arch: none
         distro: none
-        base_image: ghcr.io/${{ github.repository }}/run-on-arch-${{ github.repository_owner }}-${{ github.event.repository.name }}-build-container-aarch64-ubuntu-latest:latest # built from build-container.yaml
+        base_image: ghcr.io/${{ github.repository }}/run-on-arch-${{ github.repository_owner }}-${{ github.event.repository.name }}-build-container-aarch64-ubuntu20-04:latest # built from build-container.yaml
         setup: |
           grep -q ${{ matrix.package }} ${PWD}/3p-package-source/package_build_list_host_linux.json || rm ${PWD}/3p-package-source/package_build_list_host_linux.json
         dockerRunArgs: |

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Get package and platform from JSON changes
       id: detect-platform
       run: |
-        CHANGED_FILES=$(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} --name-only)
+        CHANGED_FILES=$(git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --name-only)
         # Construct the package and os into a json string to be consumed by Github Actions runners
         JSON="{\"include\":["
         for FILE in $CHANGED_FILES; do
@@ -47,8 +47,8 @@ jobs:
               ;;
             esac
 
-            DIFF=$(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} --no-ext-diff --unified=0 \
-                        --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get only the changes that can be built
+            DIFF=$(git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --no-ext-diff --unified=0 \
+                        --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get oly the changes that can be built
 
             if [[ $? -ne 0 ]]; then
               echo No valid build change found. Exiting with non-zero

--- a/.github/workflows/promote-packages.yaml
+++ b/.github/workflows/promote-packages.yaml
@@ -3,8 +3,17 @@
 name: Promote 3P Packages
 
 on:
-  # Allows you to run this workflow manually from the Actions tag
+  # Allows you to run this workflow manually from the Actions screen
   workflow_dispatch:
+    inputs:
+      PR-num:
+        type: string
+        required: false
+        description: PR number to pull from. Leave blank to pull from last successful run
+      Run-id-num:
+        type: string
+        required: false
+        description: Run id number (located in the build url) to pull from. Leave blank to pull from last successful run
 
   push:
     branches:
@@ -27,10 +36,25 @@ jobs:
         uses: dawidd6/action-download-artifact@v2.28.0
         with:
           workflow: build-pr-packages.yaml
-          workflow_conclusion: success
-          commit: ${{github.event.pull_request.head.sha}}
+          pr: ${{ inputs.PR-num }}
+          run_id: ${{ inputs.Run-id-num }}
           check_artifacts: true
           path: ${{ env.PACKAGE_PATH }}
+
+      - name: Check if package already exists in prod
+        env:
+          PROD_CDN: ${{ vars.PROD_CDN }} # Change this to compare on your own endpoint
+        run: |
+          find ${{ env.PACKAGE_PATH }} -type f | while read file; do
+            filename=$(basename "$file")
+            url="${{ env.PROD_CDN }}/${filename}"
+            if curl --head --silent --fail ${url} > /dev/null 2>&1; then
+              echo ${filename} already exists in prod. Check the rev in the json file to ensure it is incremented
+              exit 1
+            else
+              echo ${filename} does not exist in CDN, continuing...
+            fi
+           done
       
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
This change switches the Github Actions VM and aarch64 docker image to use Ubuntu 20.04 and pins the versions of GCC to 9 and Clang to 12. This is in line with our [AR build nodes configuration](https://github.com/o3de/o3de/blob/development/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt) and minimum supported OS dependencies.

Tested in a Jenkins sandbox with the built artifacts from https://github.com/o3de/o3de/pull/16822#issuecomment-1741523068