### PR TITLE
Add dockerfile detection, qemu env for build scripts, longpath support

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -49,10 +49,6 @@ jobs:
 
             DIFF=$(git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --no-ext-diff --unified=0 \
                         --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get oly the changes that can be built
-
-            if [[ $? -ne 0 ]]; then
-              echo No valid build change found. Exiting with non-zero
-            fi
           
             PACKAGE=$(echo $DIFF | cut -d'"' -f2)
             PACKPATH=$(echo $DIFF | egrep -o "package-system/[^ ]*")
@@ -115,8 +111,10 @@ jobs:
 
     steps:
     - name: Configure
-      id: get-user
-      run: echo "uid_gid=$(id -u):$(id -g)" >> $GITHUB_OUTPUT
+      id: configure
+      run: |
+        git config --global core.longpaths true
+        echo "uid_gid=$(id -u):$(id -g)" >> $GITHUB_OUTPUT
       
     - name: Checkout 3P source repo
       uses: actions/checkout@v4
@@ -166,8 +164,7 @@ jobs:
         max-size: 2048M
         key: ${{ matrix.package }}-${{ matrix.os }}
         restore-keys:
-          ${{ matrix.package }}-${{ matrix.os }}
-        
+          ${{ matrix.package }}-${{ matrix.os }}  
 
     - name: Set up QEMU (aarch64) # Only if the package folder contains a Dockerfile
       if: ${{ (contains(matrix.package, 'aarch64')) && (matrix.dockerfile == '1') }}

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -37,7 +37,7 @@ jobs:
               OS_RUNNER="ubuntu-20.04"
               ;;
             windows)
-              OS_RUNNER="windows-2019"
+              OS_RUNNER="windows-latest" # This is bundled with VS2022
               ;;
             darwin)
               OS_RUNNER="macos-latest"
@@ -55,8 +55,9 @@ jobs:
             fi
           
             PACKAGE=$(echo $DIFF | cut -d'"' -f2)
-      
-            JSONline="{\"package\": \"$PACKAGE\", \"os\": \"$OS_RUNNER\"},"
+            PACKPATH=$(echo $DIFF | egrep -o "package-system/[^ ]*")
+            DOCKER=$(test -f "$PACKPATH/Dockerfile" && echo 1 || echo 0)
+            JSONline="{\"package\": \"$PACKAGE\", \"os\": \"$OS_RUNNER\", \"dockerfile\": \"$DOCKER\"},"
             if [[ "$JSON" != *"$JSONline"* ]]; then
               JSON="$JSON$JSONline"
             fi
@@ -120,14 +121,14 @@ jobs:
     - name: Checkout 3P source repo
       uses: actions/checkout@v4
       with:
-        path: 3p-package-source
+        path: source
         fetch-depth: 0
     
     - name: Checkout 3P scripts repo
       uses: actions/checkout@v4
       with:
         repository: o3de/3p-package-scripts
-        path: 3p-package-scripts
+        path: scripts
       
     - name: Update python
       uses: actions/setup-python@v4
@@ -167,30 +168,36 @@ jobs:
         restore-keys:
           ${{ matrix.package }}-${{ matrix.os }}
         
+
+    - name: Set up QEMU (aarch64) # Only if the package folder contains a Dockerfile
+      if: ${{ (contains(matrix.package, 'aarch64')) && (matrix.dockerfile == '1') }}
+      run: |
+        sudo apt-get install -y qemu qemu-user-static
+
     - name: Run build command
-      if: ${{ !contains(matrix.package, 'aarch64') }}
+      if: ${{ (!contains(matrix.package, 'aarch64')) || (matrix.dockerfile == '1') }}
       env:
         CMAKE_CXX_COMPILER_LAUNCHER: sccache
         CMAKE_C_COMPILER_LAUNCHER: sccache
         CMAKE_GENERATOR: Ninja # ccache/sccache cannot be used as the compiler launcher under cmake if the generator is MSBuild
       run: |
-        python3 3p-package-scripts/o3de_package_scripts/build_package.py --search_path 3p-package-source ${{ matrix.package }}
+        python3 scripts/o3de_package_scripts/build_package.py --search_path source ${{ matrix.package }}
 
-    - name: Run build command (aarch64)
-      if: contains(matrix.package, 'aarch64')
+    - name: Run build command (aarch64) # Generic build for packages without a Dockerfile
+      if: ${{ (contains(matrix.package, 'aarch64')) && (matrix.dockerfile != '1') }}
       uses: uraimo/run-on-arch-action@v2.5.1
       with:
         arch: none
         distro: none
         base_image: ghcr.io/${{ github.repository }}/run-on-arch-${{ github.repository_owner }}-${{ github.event.repository.name }}-build-container-aarch64-ubuntu20-04:latest # built from build-container.yaml
         setup: |
-          grep -q ${{ matrix.package }} ${PWD}/3p-package-source/package_build_list_host_linux.json || rm ${PWD}/3p-package-source/package_build_list_host_linux.json
+          grep -q ${{ matrix.package }} ${PWD}/source/package_build_list_host_linux.json || rm ${PWD}/source/package_build_list_host_linux.json
         dockerRunArgs: |
           --platform=linux/arm64 
-          --user ${{ steps.get-user.outputs.uid_gid }}
+          --user ${{ steps.configure.outputs.uid_gid }}
           --volume "${PWD}:/workspace"
-          --volume "${PWD}/3p-package-scripts:/scripts"
-          --volume "${PWD}/3p-package-source:/source"
+          --volume "${PWD}/scripts:/scripts"
+          --volume "${PWD}/source:/source"
         env: |
           CMAKE_CXX_COMPILER_LAUNCHER: sccache
           CMAKE_C_COMPILER_LAUNCHER: sccache
@@ -210,7 +217,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.package }}
-        path: 3p-package-source/packages/*
+        path: source/packages/*
 
   validate-packages:
     name: Validating ${{ matrix.package }}


### PR DESCRIPTION
Adds the following features:

- Detection of a Dockerfile in the package folder. This assumes that the build script uses the Dockerfile when building for arm64
- Installation and setup of qemu for the dockerized build scripts on arm64
- Adds longpath support and shorter repo names to resolve issues with paths exceeding the 255 character limit under Windows

Tested with https://github.com/o3de/3p-package-source/pull/218 in a fork. Results of the build here: https://github.com/amzn-changml/3p-package-source/actions/runs/6492790247?pr=21