### PR TITLE
Fix to Continue Running Validation if No Script Changes are Found

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -47,9 +47,19 @@ jobs:
               ;;
             esac
 
+            # Only get the changes that can be built
+            # Check if the diff contains the word "Scripts" to ensure we only build packages that have changed
+            # Wrap the grep inside an if-statement to avoid exiting script upon non-zero exitcode.
             DIFF=$(git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --no-ext-diff --unified=0 \
-                        --exit-code -a --no-prefix -- $FILE | egrep "^\+" | grep Scripts) # Get oly the changes that can be built
-          
+                      --exit-code -a --no-prefix -- $FILE | egrep "^\+")
+                      
+            if echo "$DIFF" | grep Scripts; then
+              DIFF=$(echo "$DIFF" | grep Scripts)
+            else
+              echo "Did not find Scripts changes in file: $FILE. Skipping."
+              continue
+            fi
+
             PACKAGE=$(echo $DIFF | cut -d'"' -f2)
             PACKPATH=$(echo $DIFF | egrep -o "package-system/[^ ]*")
             DOCKER=$(test -f "$PACKPATH/Dockerfile" && echo 1 || echo 0)


### PR DESCRIPTION
Wrap the grep inside an if-statement to avoid exiting script upon non-zero exit-code.

Fixes #232