### PR TITLE
The version of PhysX cannot be built, since it fails to configure.

### DIFF
--- a/package-system/PhysX5/build_package_image.py
+++ b/package-system/PhysX5/build_package_image.py
@@ -90,6 +90,8 @@ class PhysXBuilder(object):
         self.check_call(
             ['git', 'checkout', lockToCommit,],
         )
+        # update pacman to according https://github.com/NVIDIA-Omniverse/PhysX/discussions/230
+        self.check_call(['physx/buildtools/packman/packman', 'update', '-y'])
             
     def preparePreset(self, buildAsStaticLibs, config):
         preset_index = 0


### PR DESCRIPTION
With the main branch of this repo, I've obtained an error similar to: https://github.com/NVIDIA-Omniverse/PhysX/issues/231

I resolved it by manually updating Pacman after cloning PhysX, which was proposed here https://github.com/NVIDIA-Omniverse/PhysX/discussions/230.