### PR TITLE
Add multipackage check, update action dependencies

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -28,7 +28,10 @@ jobs:
       run: |
         CHANGED_FILES=$(git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --name-only)
         # Construct the package and os into a json string to be consumed by Github Actions runners
-        JSON="{\"include\":["
+
+        declare -A PACKAGES_JSON
+        declare -A DOCKERFILE
+        
         for FILE in $CHANGED_FILES; do
           if [[ $FILE == package_build_list_host_* ]]; then
             PLATFORM=$(echo $FILE | sed -n 's/package_build_list_host_\(.*\).json/\1/p')
@@ -48,18 +51,27 @@ jobs:
             esac
 
             # Only get the changes that can be built
-            # Wrap the grep inside an if-statement to avoid exiting script upon non-zero exitcode.
-            DIFF=$(git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --no-ext-diff --unified=0 \
-                      --exit-code -a --no-prefix -- $FILE | egrep "^\+")
-
-            PACKAGE=$(echo $DIFF | cut -d'"' -f2)
-            PACKPATH=$(echo $DIFF | egrep -o "package-system/[^/ ]+(?=/| )" | head -n 1)
-            DOCKER=$(test -e ${PACKPATH%% }/Dockerfile* && echo 1 || echo 0) # Assume the build scripts will use the Dockerfile if found in the package path
-            JSONline="{\"package\": \"$PACKAGE\", \"os\": \"$OS_RUNNER\", \"dockerfile\": \"$DOCKER\"},"
-            if [[ "$JSON" != *"$JSONline"* ]]; then
-              JSON="$JSON$JSONline"
-            fi
+            IFS=$'\n' # Process each line in the package build file
+            for LINE in DIFF=$(git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} \
+                      --no-ext-diff --unified=0 \
+                      --exit-code -a --no-prefix -- $FILE | egrep "^\+[^\+]" | egrep -v "^\+\+\+ "); do
+              unset IFS # Reset IFS to avoid word splitting
+              PACKAGE=$(echo $LINE | cut -d'"' -f2)
+              PACKPATH=$(echo $LINE | egrep -o "package-system/[^/ ]+(?=/| )" | head -n 1)
+              if [[ -z "${DOCKERFILE["$PACKAGE"]}" && -n "$PACKPATH" ]]; then
+                DOCKER=$(test -e ${PACKPATH%% }/Dockerfile* && echo 1 || echo 0) # Assume the build scripts will use the Dockerfile if found in the package path
+                DOCKERFILE["$PACKAGE"]=1 # Mark Dockerfile check as done
+              fi
+              PACKAGES_JSON["$PACKAGE"]="{\"package\": \"$PACKAGE\", \"os\": \"$OS_RUNNER\", \"dockerfile\": \"$DOCKER\"}"
+            done
+            unset IFS
           fi
+        done
+
+        # Construct the complete JSON from the array
+        JSON="{\"include\":["
+        for PKG_JSON in "${PACKAGES_JSON[@]}"; do
+          JSON="$JSON$PKG_JSON,"
         done
 
         # Remove last "," and add closing brackets
@@ -141,11 +153,11 @@ jobs:
         python3 -m pip install boto3 certifi
     
     - name: Update cmake/ninja
-      uses: lukka/get-cmake@latest 
+      uses: lukka/get-cmake@latest
 
     - name: Update msbuild path
       if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1.12.0
+      uses: ilammy/msvc-dev-cmd@v1.13.0
     
     - name: Install clang/gcc
       if: runner.os == 'Linux'
@@ -184,7 +196,7 @@ jobs:
 
     - name: Run build command (aarch64) # Generic build for packages without a Dockerfile
       if: ${{ (contains(matrix.package, 'aarch64')) && (matrix.dockerfile != '1') }}
-      uses: uraimo/run-on-arch-action@v2.5.1
+      uses: uraimo/run-on-arch-action@v2.7.1
       with:
         arch: none
         distro: none
@@ -213,7 +225,7 @@ jobs:
           python3 /scripts/o3de_package_scripts/build_package.py --search_path /source/ ${{ matrix.package }}
           
     - name: Upload packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.package }}
         path: source/packages/*
@@ -227,7 +239,7 @@ jobs:
       matrix: ${{fromJson(needs.detect-changes.outputs.matrix)}}
     steps:
       - name: Download packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.package }}
           


### PR DESCRIPTION
Adds a multipackage loop for package builds that have more than one package in the platform file (such as Windows/Android and Mac/iOS)

Also updates some of the Github Actions dependencies to their respective latest versions

Tested in my fork against the [AWSSDK 1.11.288 PR](https://github.com/o3de/3p-package-source/pull/249): https://github.com/amzn-changml/3p-package-source/actions/runs/8625647372