### PR TITLE
Forcing New Assimp Artifacts

### DIFF
--- a/package-system/assimp/PackageInfo.json
+++ b/package-system/assimp/PackageInfo.json
@@ -1,5 +1,5 @@
 {
-  "PackageName": "assimp-5.4.3-rev2",
+  "PackageName": "assimp-5.4.3-rev3",
   "URL": "https://github.com/assimp/assimp/blob/master/LICENSE",
   "License": "BSD-3-Clause",
   "LicenseFile": "LICENSE"

--- a/package-system/assimp/build_config.json
+++ b/package-system/assimp/build_config.json
@@ -2,7 +2,7 @@
     "git_url":"https://github.com/assimp/assimp",
     "git_tag": "v5.4.3",
     "package_name":"assimp",
-    "package_version":"5.4.3-rev2",
+    "package_version":"5.4.3-rev3",
     "package_url":"https://github.com/assimp/assimp",
     "package_license":"BSD-3-Clause",
     "package_license_file":"LICENSE",

--- a/package_build_list_host_darwin.json
+++ b/package_build_list_host_darwin.json
@@ -4,7 +4,7 @@
     "comment3" : "build_from_folder is package name --> folder containing built image of package",
     "comment4" : "Note:  Build from source occurs before build_from_folder",
     "build_from_source": {
-        "assimp-5.4.3-rev2-mac":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Mac --package-root ../../package-system --clean",
+        "assimp-5.4.3-rev3-mac":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Mac --package-root ../../package-system --clean",
         "AWSNativeSDK-1.11.361-rev1-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Mac --package-root ../../package-system --clean",
         "AWSNativeSDK-1.11.361-rev1-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name iOS --package-root ../../package-system --clean",
         "Lua-5.4.4-rev1-mac": "Scripts/extras/pull_and_build_from_git.py ../../package-system/Lua --platform-name Mac --package-root ../../package-system/Lua/temp --clean",
@@ -55,7 +55,7 @@
         "expat-2.4.2-rev2-ios": "Scripts/extras/pull_and_build_from_git.py ../../package-system/expat --platform-name iOS --package-root ../../package-system/expat/temp --clean"
     },
     "build_from_folder": {
-        "assimp-5.4.3-rev2-mac": "package-system/assimp-mac",
+        "assimp-5.4.3-rev3-mac": "package-system/assimp-mac",
         "AWSNativeSDK-1.11.361-rev1-mac": "package-system/AWSNativeSDK-mac",
         "AWSNativeSDK-1.11.361-rev1-ios": "package-system/AWSNativeSDK-ios",
         "AwsIotDeviceSdkCpp-1.15.2-rev2-mac": "package-system/AwsIotDeviceSdkCpp-mac",

--- a/package_build_list_host_linux-aarch64.json
+++ b/package_build_list_host_linux-aarch64.json
@@ -4,7 +4,7 @@
     "comment3" : "build_from_folder is package name --> folder containing built image of package",
     "comment4" : "Note:  Build from source occurs before build_from_folder",
     "build_from_source": {
-        "assimp-5.4.3-rev2-linux-aarch64":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Linux-aarch64 --clean",
+        "assimp-5.4.3-rev3-linux-aarch64":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Linux-aarch64 --clean",
         "astc-encoder-3.2-rev3-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/astc-encoder --platform-name Linux-aarch64 --clean",
         "AWSGameLiftServerSDK-5.1.2-rev1-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSGameLiftServerSDK --platform-name Linux-aarch64 --clean",
         "AwsIotDeviceSdkCpp-1.15.2-rev1-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AwsIotDeviceSdkCpp --platform-name Linux-aarch64 --clean",
@@ -45,7 +45,7 @@
         "zlib-1.2.11-rev5-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Linux-aarch64 --clean"
     },
     "build_from_folder": {
-        "assimp-5.4.3-rev2-linux-aarch64": "package-system/assimp/temp/assimp-linux-aarch64",
+        "assimp-5.4.3-rev3-linux-aarch64": "package-system/assimp/temp/assimp-linux-aarch64",
         "astc-encoder-3.2-rev3-linux-aarch64": "package-system/astc-encoder/temp/astc-encoder-linux-aarch64",
         "AWSGameLiftServerSDK-5.1.2-rev1-linux-aarch64": "package-system/AWSGameLiftServerSDK/temp/AWSGameLiftServerSDK-linux-aarch64",
         "AwsIotDeviceSdkCpp-1.15.2-rev1-linux-aarch64": "package-system/AwsIotDeviceSdkCpp/temp/AwsIotDeviceSdkCpp-linux-aarch64",

--- a/package_build_list_host_linux.json
+++ b/package_build_list_host_linux.json
@@ -4,8 +4,8 @@
     "comment3" : "build_from_folder is package name --> folder containing built image of package",
     "comment4" : "Note:  Build from source occurs before build_from_folder",
     "build_from_source": {
-        "assimp-5.4.3-rev2-linux":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Linux --package-root ../../package-system --clean",
-        "assimp-5.4.3-rev2-linux-aarch64":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Linux-aarch64 --package-root ../../package-system --clean",
+        "assimp-5.4.3-rev3-linux":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Linux --package-root ../../package-system --clean",
+        "assimp-5.4.3-rev3-linux-aarch64":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Linux-aarch64 --package-root ../../package-system --clean",
         "AWSGameLiftServerSDK-5.1.2-rev1-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSGameLiftServerSDK --platform-name Linux --clean",
         "AWSGameLiftServerSDK-5.1.2-rev1-linux-aarch64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSGameLiftServerSDK --platform-name Linux-aarch64 --clean",
         "AWSNativeSDK-1.11.361-rev1-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Linux --clean",
@@ -53,8 +53,8 @@
         "vulkan-validationlayers-1.2.198-rev1-linux": "Scripts/extras/pull_and_build_from_git.py ../../package-system/vulkan-validationlayers --platform-name Linux --package-root ../../package-system/vulkan-validationlayers/temp --clean"
     },
     "build_from_folder": {
-        "assimp-5.4.3-rev2-linux": "package-system/assimp-linux",
-        "assimp-5.4.3-rev2-linux-aarch64": "package-system/assimp-linux-aarch64",
+        "assimp-5.4.3-rev3-linux": "package-system/assimp-linux",
+        "assimp-5.4.3-rev3-linux-aarch64": "package-system/assimp-linux-aarch64",
         "AWSGameLiftServerSDK-5.1.2-rev1-linux": "package-system/AWSGameLiftServerSDK/temp/AWSGameLiftServerSDK-linux",
         "AWSGameLiftServerSDK-5.1.2-rev1-linux-aarch64": "package-system/AWSGameLiftServerSDK/temp/AWSGameLiftServerSDK-linux-aarch64",
         "AWSNativeSDK-1.11.361-rev1-linux": "package-system/AWSNativeSDK/temp/AWSNativeSDK-linux",

--- a/package_build_list_host_windows.json
+++ b/package_build_list_host_windows.json
@@ -4,7 +4,7 @@
     "comment3" : "build_from_folder is package name --> folder containing built image of package",
     "comment4" : "Note:  Build from source occurs before build_from_folder",
     "build_from_source": {
-        "assimp-5.4.3-rev2-windows":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Windows --package-root ../../package-system --clean",
+        "assimp-5.4.3-rev3-windows":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Windows --package-root ../../package-system --clean",
         "astc-encoder-3.2-rev2-windows": "Scripts/extras/pull_and_build_from_git.py ../../package-system/astc-encoder --platform-name Windows --package-root ../../package-system --clean",
         "azslc-1.8.22-rev1-windows": "Scripts/extras/pull_and_build_from_git.py ../../package-system/azslc --platform-name Windows --package-root ../../package-system/azslc/temp --clean",
         "AWSGameLiftServerSDK-5.1.2-rev1-windows": "package-system/AWSGameLiftServerSDK/build_package_image.py --platform-name windows",
@@ -66,7 +66,7 @@
   },
   "build_from_folder": {
     "alembic-1.7.11-rev3-multiplatform": "package-system/alembic-multiplatform",
-    "assimp-5.4.3-rev2-windows": "package-system/assimp-windows",
+    "assimp-5.4.3-rev3-windows": "package-system/assimp-windows",
     "astc-encoder-3.2-rev2-windows": "package-system/astc-encoder-windows",
     "azslc-1.8.22-rev1-windows": "package-system/azslc/temp/azslc-windows",
     "AWSGameLiftServerSDK-5.1.2-rev1-windows": "package-system/AWSGameLiftServerSDK-windows",


### PR DESCRIPTION
Bumping version number so that github actions produces new artifacts; the last assimp PR didn't contain a version bump because the package wasn't actually updating in o3de, but a bump is required for github actions to pick up on the change.