### PR TITLE
Added "-DANDROID_STL=c++_shared" to build_config.json

### DIFF
--- a/package-system/OpenXR/build_config.json
+++ b/package-system/OpenXR/build_config.json
@@ -46,7 +46,8 @@
             "cmake_generate_args" : [
                "-G",
                "\"Ninja Multi-Config\"",
-               "-DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/Android/Toolchain_android.cmake"
+               "-DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/Android/Toolchain_android.cmake",
+               "-DANDROID_STL=c++_shared"
             ],
             "custom_test_cmd" : [
            ]


### PR DESCRIPTION
In order to avoid linker error from Jenkins CI:
```
ld: error: undefined symbol: vtable for std::__ndk1::basic_ostringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >
```