### PR TITLE
Utilize arm64 native runners for 3p builds

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -141,7 +141,7 @@ jobs:
 
     - name: Expand disk size for Linux
       uses: easimon/maximize-build-space@v10
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && !contains(matrix.os, 'arm')
       with:
         root-reserve-mb: 20000
         swap-size-mb: 200

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -234,7 +234,7 @@ jobs:
 
     - name: Use sccache
       uses: hendrikmuhs/ccache-action@v1.2.10
-      if: !contains(matrix.os, 'arm')
+      if: ${{ !contains(matrix.os, 'arm') }}
       with:
         variant: sccache
         max-size: 2048M

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -36,10 +36,10 @@ jobs:
           if [[ $FILE == package_build_list_host_* ]]; then
             PLATFORM=$(echo $FILE | sed -n 's/package_build_list_host_\(.*\).json/\1/p')
             case $PLATFORM in
-            linux-aarch64)
+            *linux-aarch64)
               OS_RUNNER="ubuntu-22.04-arm"
               ;;
-            linux)
+            *linux)
               OS_RUNNER="ubuntu-22.04"
               ;;
             windows)
@@ -249,36 +249,6 @@ jobs:
         CMAKE_GENERATOR: Ninja # ccache/sccache cannot be used as the compiler launcher under cmake if the generator is MSBuild
       run: |
         python3 scripts/o3de_package_scripts/build_package.py --search_path source ${{ matrix.package }}
-
-    - name: Run build command (Docker) # Generic build for packages without a Dockerfile
-      if: ${{ matrix.dockerfile != '1' }}
-      uses: uraimo/run-on-arch-action@v2.7.1
-      with:
-        arch: none
-        distro: none
-        base_image: ghcr.io/${{ github.repository }}/run-on-arch-${{ github.repository_owner }}-${{ github.event.repository.name }}-build-container-aarch64-ubuntu20-04:latest # built from build-container.yaml
-        setup: |
-          grep -q ${{ matrix.package }} ${PWD}/source/package_build_list_host_linux.json || rm ${PWD}/source/package_build_list_host_linux.json
-        dockerRunArgs: |
-          --platform=linux/arm64 
-          --user ${{ steps.configure.outputs.uid_gid }}
-          --volume "${PWD}:/workspace"
-          --volume "${PWD}/scripts:/scripts"
-          --volume "${PWD}/source:/source"
-        env: |
-          CMAKE_CXX_COMPILER_LAUNCHER: sccache
-          CMAKE_C_COMPILER_LAUNCHER: sccache
-          SCCACHE_IDLE_TIMEOUT: 0 
-          SCCACHE_DIR: /workspace/.sccache
-          SCCACHE_CACHE_SIZE: 2048M
-        shell: /bin/bash
-        run: |
-          lsb_release -a
-          uname -a
-          sccache --start-server
-          sccache -z
-          ls -lah /workspace
-          python3 /scripts/o3de_package_scripts/build_package.py --search_path /source/ ${{ matrix.package }}
           
     - name: Upload packages
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -41,6 +41,7 @@ jobs:
               ;;
             linux)
               OS_RUNNER="ubuntu-22.04"
+              ;;
             windows)
               OS_RUNNER="windows-latest" # This is bundled with VS2022
               ;;

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -234,6 +234,7 @@ jobs:
 
     - name: Use sccache
       uses: hendrikmuhs/ccache-action@v1.2.10
+      if: !contains(matrix.os, 'arm')
       with:
         variant: sccache
         max-size: 2048M

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -243,7 +243,6 @@ jobs:
           ${{ matrix.package }}-${{ matrix.os }}  
 
     - name: Run build command
-      if: ${{ matrix.dockerfile == '1' }}
       env:
         CMAKE_CXX_COMPILER_LAUNCHER: sccache
         CMAKE_C_COMPILER_LAUNCHER: sccache

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -36,9 +36,11 @@ jobs:
           if [[ $FILE == package_build_list_host_* ]]; then
             PLATFORM=$(echo $FILE | sed -n 's/package_build_list_host_\(.*\).json/\1/p')
             case $PLATFORM in
-            linux*)
-              OS_RUNNER="ubuntu-20.04"
+            linux-aarch64)
+              OS_RUNNER="ubuntu-22.04-arm"
               ;;
+            linux)
+              OS_RUNNER="ubuntu-22.04"
             windows)
               OS_RUNNER="windows-latest" # This is bundled with VS2022
               ;;
@@ -238,13 +240,8 @@ jobs:
         restore-keys:
           ${{ matrix.package }}-${{ matrix.os }}  
 
-    - name: Set up QEMU (aarch64) # Only if the package folder contains a Dockerfile
-      if: ${{ (contains(matrix.package, 'aarch64')) && (matrix.dockerfile == '1') }}
-      run: |
-        sudo apt-get install -y qemu qemu-user-static
-
     - name: Run build command
-      if: ${{ (!contains(matrix.package, 'aarch64')) || (matrix.dockerfile == '1') }}
+      if: ${{ matrix.dockerfile == '1' }}
       env:
         CMAKE_CXX_COMPILER_LAUNCHER: sccache
         CMAKE_C_COMPILER_LAUNCHER: sccache
@@ -252,8 +249,8 @@ jobs:
       run: |
         python3 scripts/o3de_package_scripts/build_package.py --search_path source ${{ matrix.package }}
 
-    - name: Run build command (aarch64) # Generic build for packages without a Dockerfile
-      if: ${{ (contains(matrix.package, 'aarch64')) && (matrix.dockerfile != '1') }}
+    - name: Run build command (Docker) # Generic build for packages without a Dockerfile
+      if: ${{ matrix.dockerfile != '1' }}
       uses: uraimo/run-on-arch-action@v2.7.1
       with:
         arch: none


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building packages, introducing support for ARM-based Linux runners and simplifying the build process.

### ARM-specific runner support:
* Updated the `OS_RUNNER` assignment to include `ubuntu-22.04-arm` for ARM-based Linux builds, ensuring compatibility with ARM architectures without needing QEMU virtualization

### Workflow optimizations:
* Adjusted the disk expansion step to exclude ARM runners, preventing unnecessary operations on ARM-based builds. 

* Added a condition to skip the `sccache` setup for ARM builds, as it is not compatible