### PR TITLE
Mac ARM64 3P support : Initial setup for Mac ARM64

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -75,7 +75,7 @@ jobs:
                 PACKAGE_OS="windows-latest"
                 echo "OS Image selected for $PACKAGE: $PACKAGE_OS"
               elif [[ $PLATFORM =~ "darwin" ]]; then
-                PACKAGE_OS="macos-13"
+                PACKAGE_OS="macos-15"
                 echo "OS Image selected for $PACKAGE: $PACKAGE_OS"
               else
                 PACKAGE_OS="windows-latest" # Default

--- a/Scripts/cmake/Platform/Mac/Toolchain_mac.cmake
+++ b/Scripts/cmake/Platform/Mac/Toolchain_mac.cmake
@@ -11,7 +11,7 @@
 # in all 3p packages so that they don't have to seperately define this for each one.
 
 set(CMAKE_SYSTEM_NAME Darwin)
-set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "The minimum OSX Version to support" FORCE)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "15.0" CACHE STRING "The minimum OSX Version to support" FORCE)
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
 # If we need to compile for Mac M1, set CMAKE_APPLE_SILICON_PROCESSOR to arm64 on the command line.

--- a/package_build_list_host_darwin-arm64.json
+++ b/package_build_list_host_darwin-arm64.json
@@ -1,0 +1,10 @@
+{
+    "comment" : "This is the list that applies to darwin arm64 (Mac Silicon) hosts",
+    "comment2" : "build_from_source is package name --> build script to call with params",
+    "comment3" : "build_from_folder is package name --> folder containing built image of package",
+    "comment4" : "Note:  Build from source occurs before build_from_folder",
+    "build_from_source": {
+    },
+    "build_from_folder": {
+    }
+}


### PR DESCRIPTION
* Create new package_build_list* file for darwin-arm64
* Update Mac Toolchain to deployment target of 15
* Update build-package.yaml to use os 'macos-15'