### PR TITLE
Fix the promote-packages.yaml for Mac

### DIFF
--- a/.github/workflows/promote-packages.yaml
+++ b/.github/workflows/promote-packages.yaml
@@ -119,7 +119,10 @@ jobs:
                 PLATFORM=linux
             elif [[ $file == *linux ]]; then
                 CMAKE_FILE=BuiltInPackages_linux_x86_64.cmake
-            elif [[ $file == *darwin ]]; then
+            elif [[ $file == *mac-arm64 ]]; then
+                CMAKE_FILE=BuiltInPackages_mac_arm64.cmake
+                PLATFORM=mac
+            elif [[ $file == *mac ]]; then
                 CMAKE_FILE=BuiltInPackages_mac.cmake
                 PLATFORM=mac
             else


### PR DESCRIPTION
Fix the promote-packages.yaml to select the correct Builtin-* packages file for mac and mac-arm64