### PR TITLE
Mac ARM64 3P support: Add definition for OpenEXR-3.4.4-rev1-mac-arm64

### DIFF
--- a/package-system/OpenEXR/build_config.json
+++ b/package-system/OpenEXR/build_config.json
@@ -77,6 +77,22 @@
                "./test_openexr_mac.sh"
             ]
          },
+         "Mac-arm64":{
+            "git_tag":"v3.4.4",
+            "package_version":"3.4.4-rev1",
+            "build_configs" : ["Release"],
+            "depends_on_packages" :[
+               ["zlib-1.3.1-rev2-mac-arm64", "52e62890329d3e003226fca88df30701cdd862a5f137eb5f75dff504377c13b3", ""]
+            ],
+            "custom_toolchain_file" : "../cmake/Platform/Mac/Toolchain_mac.cmake",
+            "cmake_generate_args_release": [
+               "-G",
+               "Xcode"
+            ],
+            "custom_test_cmd" : [
+               "./test_openexr_mac_3_4.sh"
+            ]
+         },
          "iOS":{
             "build_configs" : ["Release"],
             "depends_on_packages" :[ 

--- a/package-system/OpenEXR/test/CMakeLists.txt
+++ b/package-system/OpenEXR/test/CMakeLists.txt
@@ -13,6 +13,10 @@ PROJECT(test_openexr VERSION 1.0 LANGUAGES C CXX)
 find_package(OpenEXR)
 find_package(Imath)
 
+if (OPENEXR_TEST_VER_3_4)
+    add_compile_definitions(OPENEXR_TEST_VER_3_4)
+endif()
+
 add_executable(test_openexr test_openexr.cpp)
 
 # note that we use 3rdParty::OpenEXR here.  This will ONLY work 

--- a/package-system/OpenEXR/test/test_openexr.cpp
+++ b/package-system/OpenEXR/test/test_openexr.cpp
@@ -9,8 +9,13 @@
 #include <ImfHeader.h>
 #include <ImfChannelList.h>
 
+#if defined(OPENEXR_TEST_VER_3_4)
+using namespace Imf_3_4;
+using namespace Imath_3_2;
+#else
 using namespace Imf_3_1;
 using namespace Imath_3_1;
+#endif
 
 int
 readHeader(const char fileName[],

--- a/package-system/OpenEXR/test_openexr_mac_3_4.sh
+++ b/package-system/OpenEXR/test_openexr_mac_3_4.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+rm -rf temp/build_test
+mkdir temp/build_test
+
+cmake -S test -B temp/build_test -G Xcode \
+    -DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/Mac/Toolchain_mac.cmake \
+    -DCMAKE_MODULE_PATH="$DOWNLOADED_PACKAGE_FOLDERS;$PACKAGE_ROOT" \
+    -DOPENEXR_TEST_VER_3_4=TRUE || exit 1
+
+cmake --build temp/build_test --parallel --config Release || exit 1
+temp/build_test/Release/test_openexr.app/Contents/MacOS/test_openexr || exit 1
+
+cmake --build temp/build_test --parallel --config Debug || exit 1
+temp/build_test/Debug/test_openexr.app/Contents/MacOS/test_openexr || exit 1
+
+exit 0

--- a/package_build_list_host_darwin-arm64.json
+++ b/package_build_list_host_darwin-arm64.json
@@ -6,12 +6,13 @@
     "build_from_source": {
         "assimp-5.4.3-rev3-mac-arm64":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Mac-arm64 --clean",
         "expat-2.7.3-rev1-mac-arm64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/expat --platform-name Mac-arm64 --clean",
-        "png-1.6.53-rev1-mac-arm64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/libpng --platform-name Mac-arm64 --clean",
+        "OpenEXR-3.4.4-rev1-mac-arm64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/OpenEXR --platform-name Mac-arm64 --clean",        "png-1.6.53-rev1-mac-arm64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/libpng --platform-name Mac-arm64 --clean",
         "zlib-1.3.1-rev2-mac-arm64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/zlib --platform-name Mac-arm64 --clean"
     },
     "build_from_folder": {
         "assimp-5.4.3-rev3-mac-arm64": "package-system/assimp/temp/assimp-mac-arm64",
         "expat-2.7.3-rev1-mac-arm64": "package-system/expat/temp/expat-mac-arm64",
+        "OpenEXR-3.4.4-rev1-mac-arm64": "package-system/OpenEXR/temp/OpenEXR-mac-arm64",
         "png-1.6.53-rev1-mac-arm64": "package-system/libpng/temp/png-mac-arm64",
         "zlib-1.3.1-rev2-mac-arm64": "package-system/zlib/temp/zlib-mac-arm64"
     }


### PR DESCRIPTION
* Add new entry in package-system/OpenEXR/build_config.json for `Mac-arm64`
* Updated version of OpenEXR to 3.4.4 for Mac-arm64
* Added `OpenEXR-3.4.4-rev1-mac-arm64` into package_build_list_host_darwin-arm64.json`

[build_openexr.log](https://github.com/user-attachments/files/24631707/build_openexr.log)


Fixes https://github.com/o3de/3p-package-source/issues/321 

