### PR TITLE
Fix astc-encoder Findastc-encoder.cmake error for Mac ARM64

### DIFF
--- a/package-system/astc-encoder/Findastc-encoder.cmake.mac-arm64
+++ b/package-system/astc-encoder/Findastc-encoder.cmake.mac-arm64
@@ -1,0 +1,32 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# 
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+# this file actually ingests the library and defines targets.
+
+
+set(LIB_NAME "astc-encoder")
+set(TARGET_WITH_NAMESPACE "3rdParty::${LIB_NAME}")
+
+set(${LIB_NAME}_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/${LIB_NAME}/include)
+set(${LIB_NAME}_LIBRARY_DIR ${CMAKE_CURRENT_LIST_DIR}/${LIB_NAME}/bin)
+
+set(${LIB_NAME}_LIBRARY_RELEASE ${${LIB_NAME}_LIBRARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}astcenc-neon-static${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(${LIB_NAME}_LIBRARY_DEBUG ${${LIB_NAME}_LIBRARY_RELEASE})
+
+# declare the target so that others can 'depend on it'
+add_library(${TARGET_WITH_NAMESPACE} STATIC IMPORTED GLOBAL)
+
+# add include directory
+ly_target_include_system_directories(TARGET ${TARGET_WITH_NAMESPACE} INTERFACE ${${LIB_NAME}_INCLUDE_DIR})
+
+# add static library as "output" IMPORTED_LOCATION for the target
+set_target_properties(${TARGET_WITH_NAMESPACE}
+    PROPERTIES
+        IMPORTED_LOCATION_DEBUG ${${LIB_NAME}_LIBRARY_DEBUG}
+        IMPORTED_LOCATION ${${LIB_NAME}_LIBRARY_RELEASE}
+)
+
+set(${LIB_NAME}_FOUND True)

--- a/package-system/astc-encoder/build_config.json
+++ b/package-system/astc-encoder/build_config.json
@@ -32,8 +32,8 @@
                 ]
             },
             "Mac-arm64": {
-                "cmake_find_template": "Findastc-encoder.cmake.template",
-                "package_version": "3.2-rev5",
+                "cmake_find_source": "Findastc-encoder.cmake.mac-arm64",
+                "package_version": "3.2-rev6",
                 "custom_build_cmd": [
                     "./build_mac_arm64.sh"
                 ],
@@ -53,7 +53,7 @@
                 ]
             },
 	    "Linux-aarch64": {
-		"cmake_find_source": "Findastc-encoder.cmake.linux-aarch64",
+		    "cmake_find_source": "Findastc-encoder.cmake.linux-aarch64",
                 "custom_build_cmd": [
                     "./build-linux.sh"
                 ],

--- a/package_build_list_host_darwin-arm64.json
+++ b/package_build_list_host_darwin-arm64.json
@@ -5,7 +5,7 @@
     "comment4" : "Note:  Build from source occurs before build_from_folder",
     "build_from_source": {
         "assimp-5.4.3-rev4-mac-arm64":  "Scripts/extras/pull_and_build_from_git.py ../../package-system/assimp --platform-name Mac-arm64 --clean",
-        "astc-encoder-3.2-rev5-mac-arm64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/astc-encoder --platform-name Mac-arm64 --clean",
+        "astc-encoder-3.2-rev6-mac-arm64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/astc-encoder --platform-name Mac-arm64 --clean",
         "AWSNativeSDK-1.11.361-rev1-mac-arm64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/AWSNativeSDK --platform-name Mac-arm64 --clean",
         "azslc-1.8.22-rev1-mac-arm64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/azslc --platform-name Mac-arm64 --package-root ../../package-system/azslc/temp --clean",
         "cityhash-1.1-rev1-mac-arm64": "Scripts/extras/pull_and_build_from_git.py ../../package-system/cityhash --platform-name Mac-arm64 --clean",
@@ -38,7 +38,7 @@
     },
     "build_from_folder": {
         "assimp-5.4.3-rev4-mac-arm64": "package-system/assimp/temp/assimp-mac-arm64",
-        "astc-encoder-3.2-rev5-mac-arm64": "package-system/astc-encoder/temp/astc-encoder-mac-arm64",
+        "astc-encoder-3.2-rev6-mac-arm64": "package-system/astc-encoder/temp/astc-encoder-mac-arm64",
         "AWSNativeSDK-1.11.361-rev1-mac-arm64": "package-system/AWSNativeSDK/temp/AWSNativeSDK-mac-arm64",
         "azslc-1.8.22-rev1-mac-arm64": "package-system/azslc/temp/azslc-mac-arm64",
         "cityhash-1.1-rev1-mac-arm64": "package-system/cityhash/temp/cityhash-mac-arm64",


### PR DESCRIPTION
The Findastc-encoder.cmake for Mac ARM64 was using the combined template source that was loading the x86 version of the static library, not the arm64 (neon) version.

