### PR TITLE
Modernize Android 3p build scripts for current NDK/CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ TestResults/**
 .pytest_cache
 packages/
 **/temp/**
+**/build/**
 qt_compile_log.txt
 .remote_cache.json
 .venv/

--- a/Scripts/cmake/Platform/Android/Toolchain_android.cmake
+++ b/Scripts/cmake/Platform/Android/Toolchain_android.cmake
@@ -58,6 +58,9 @@ set(CMAKE_CXX_FLAGS "-fPIC")
 # Make a backup of the CMAKE_FIND_ROOT_PATH since it will be altered by the NDK toolchain file and needs to be restored after the input
 set(BACKUP_CMAKE_FIND_ROOT_PATH ${CMAKE_FIND_ROOT_PATH})
 
+# Use the modern NDK toolchain (not the legacy one which is broken with CMake 4.x)
+set(ANDROID_USE_LEGACY_TOOLCHAIN_FILE OFF)
+
 include(${LY_ANDROID_NDK_TOOLCHAIN})
 
 set(CMAKE_FIND_ROOT_PATH ${BACKUP_CMAKE_FIND_ROOT_PATH})

--- a/package-system/mikkelsen/build_package_image.py
+++ b/package-system/mikkelsen/build_package_image.py
@@ -57,12 +57,8 @@ folder_names = {
         '-G', 'Ninja Multi-Config',
         f'-DCMAKE_TOOLCHAIN_FILE={cmake_scripts_path}/Platform/Android/Toolchain_android.cmake',
         '-DANDROID_ABI=arm64-v8a',
-        '-DANDROID_ARM_MODE=arm',
-        '-DANDROID_ARM_NEON=FALSE',
-        '-DANDROID_NATIVE_API_LEVEL=21',
-        f'-DLY_NDK_DIR={ly_3rdparty_path}/android-ndk/r21d',
         '-DPACKAGE_PLATFORM=android'
-    ], []) # Android needs to have ninja in the path
+    ], []) # Android needs to have ninja in the path and LY_NDK_DIR env var set
 }
 
 # intentionally generate a keyerror if its not a good platform:

--- a/package-system/zlib/build_zlib_android.cmd
+++ b/package-system/zlib/build_zlib_android.cmd
@@ -10,6 +10,7 @@
 cmake -S temp/src -B temp/build -G Ninja ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_CXX_STANDARD=17 ^
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
     -DCMAKE_TOOLCHAIN_FILE=../../../../Scripts/cmake/Platform/Android/Toolchain_android.cmake ^
     -DBUILD_SHARED_LIBS=OFF ^
     -DSKIP_INSTALL_FILES=YES


### PR DESCRIPTION
## What does this PR do?

Fixes the Android 3p package build scripts so they work with current NDK and CMake versions. No functional change to package outputs.

- **Toolchain**: opt out of the NDK's legacy toolchain wrapper (`ANDROID_USE_LEGACY_TOOLCHAIN_FILE OFF`), which is broken with CMake 4.x
- **mikkelsen**: remove hardcoded NDK r21d path (uses the `LY_NDK_DIR` env var, which the toolchain already supports), drop the API level pin (toolchain enforces and defaults to 24), remove obsolete arm32 flags (`ANDROID_ARM_MODE`/`ANDROID_ARM_NEON` modern NDKs hard-error on disabling NEON, and both are meaningless for arm64-v8a)
- **zlib**: pass `CMAKE_POLICY_VERSION_MINIMUM=3.5` so zlib's ancient `cmake_minimum_required(VERSION 2.4.4)` configures under CMake 4.x (must be on the command line the top-level version check runs before the toolchain file is read)
- **.gitignore**: exclude `build/` folders

## How was this tested?

Built with NDK r27.3.13750724 / CMake 4.1 on Windows:
- mikkelsen: debug + release via Ninja Multi-Config, both installed correctly
- zlib: `build_zlib_android.cmd` links `libz.a` cleanly

## Related

Prerequisite for the Android 16KB page alignment work: RFC o3de/o3de#19936
