### PR TITLE
Android: Add 16KB page size alignment to shared toolchain

### DIFF
--- a/Scripts/cmake/Platform/Android/Toolchain_android.cmake
+++ b/Scripts/cmake/Platform/Android/Toolchain_android.cmake
@@ -73,6 +73,12 @@ set(CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH ON)
 set(LINKER_FLAGS ${ANDROID_LINKER_FLAGS})
 set(CMAKE_CXX_STANDARD_LIBRARIES "")
 
+# 16KB page size support: Required by Google Play for apps targeting Android 15+ devices (Nov 2025).
+# These flags ensure all shared libraries have ELF segments aligned to 16KB boundaries,
+# which is backward compatible with 4KB-page devices.
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384")
+
 # We need to pass down the Android API Level, and the Package Revision's Major and Minor number as preprocessor values.
 # We will extract them from 'ANDROID_NDK_SOURCE_PROPERTIES' which will read from the NDK's properties file.
 # (note: we cannot use 'ANDROID_NDK_REVISION' because the toolchain combines the Major and Minor revisions


### PR DESCRIPTION
## What does this PR do?

Adds 16KB page size alignment linker flags to the shared Android toolchain used by all 3p package builds:

```
-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384
```

This ensures all Android shared libraries have ELF LOAD segments aligned to 16KB boundaries, as required by Google Play for apps targeting Android 15+ devices (enforced since November 1, 2025). 16KB-aligned binaries are fully backward compatible with 4KB-page devices.

All packages that build for Android through this toolchain (expat, freetype, googlebenchmark, libpng, libsamplerate, Lua, lz4, mikkelsen, OpenSSL, tiff, zlib) will produce aligned output on their next rebuild.

Note: vulkan-validationlayers uses prebuilt Khronos binaries and needs an updated upstream version separately.

## RFC

**Draft pending acceptance of RFC o3de/o3de#19936** (Android 16KB Page Size Support for O3DE Native Binaries).

Depends on #388 (build script modernization) for the packages to be rebuildable with a current NDK/CMake.

## Verification

`llvm-readelf -l <lib.so>` on rebuilt output must show all LOAD segments with `Align 0x4000` or greater.
