### PR TITLE
Upgrades to pull_and_build_from_git.py to support upcoming libraries

### DIFF
--- a/Scripts/extras/pull_and_build_from_git.py
+++ b/Scripts/extras/pull_and_build_from_git.py
@@ -92,6 +92,10 @@ The following keys can exist at the root level or the target-platform level:
                                             install tree will be copied to the target package.
                                             This field can exist at the root but also at individual platform target level.
 
+* clean_between_configurations            : (optional), default False.  If True, the build folder will be erased between compiling
+                                            different configurations.
+
+* set_env_vars                            : dictionary of env vars to set { "key" : "value" , ... }
 
 The following keys can only exist at the target platform level as they describe the specifics for that platform.
 
@@ -155,6 +159,18 @@ The following keys can only exist at the target platform level as they describe 
                                                file hash - The hex-string of the fingerprint to validate the download with. If this is left blank, no validation
                                                            will be done, instead it will be calculated on the downloaded package and printed to the console.
                                                hash algorithm - The hash algorithm to use to calculate the file hash.
+
+* additional_src_files                   : individual files to copy from the local folder into
+                                           the temp src folder before build.
+                                           elements in this list can either be a string
+                                           filename,
+                                           or a list of 2 elements, the first being the string
+                                           filename, and the second being a relative path from
+                                           temp.
+                                           E.g:
+                                           [  "extrafile.txt", "anotherfile.txt" ] - copied into temp/src/anotherfile.txt
+                                           [ [ "extrafile.txt", "dest/foo.txt"],   - copied into temp/dest/foo.txt
+                                           [ "anotherfile.txt" ] - copied into temp/src/bar.txt
 
 
 Note about environment variables:
@@ -276,7 +292,7 @@ class PackageInfo(object):
         self.git_commit = _get_value("git_commit", required=False)
         self.cmake_find_template = _get_value("cmake_find_template", required=False)
         self.cmake_find_source = _get_value("cmake_find_source", required=False)
-        self.cmake_find_target = _get_value("cmake_find_target")
+        self.cmake_find_target = _get_value("cmake_find_target", required=False)
         self.cmake_find_template_custom_indent = _get_value("cmake_find_template_custom_indent", default=1)
         self.additional_src_files = _get_value("additional_src_files", required=False)
         self.depends_on_packages = _get_value("depends_on_packages", required=False)
@@ -288,6 +304,8 @@ class PackageInfo(object):
         self.extra_files_to_copy = _get_value("extra_files_to_copy", required=False)
         self.cmake_install_filter = _get_value("cmake_install_filter", required=False, default=[])
         self.custom_toolchain_file = _get_value("custom_toolchain_file", required=False)
+        self.clean_between_configurations = _get_value("clean_between_configurations", required=False, default=False)
+        self.set_env_vars = _get_value("set_env_vars", required=False, default={})
 
         if self.cmake_find_template and self.cmake_find_source:
             raise BuildError("Bad build config file. 'cmake_find_template' and 'cmake_find_source' cannot both be set in the configuration.")
@@ -394,6 +412,9 @@ def delete_folder(folder):
         print(f"Expected a folder, but found a file: {path_folder}")
     if not path_folder.is_dir():
         return
+
+    if os.path.dirname(path_folder) == path_folder: # is it the root folder?
+        raise BuildError(f"Was told to erase folder {path_folder} but that seems like a bad idea.")
 
     if platform.system() == 'Windows':
         call_result = subprocess.run(subp_args(['rmdir', '/Q', '/S', str(path_folder)]),
@@ -626,17 +647,6 @@ class BuildInfo(object):
         else:
             raise BuildError(f"Missing both 'git_url' and 'src_package_url' from the build config")
 
-
-        if self.package_info.additional_src_files:
-            for additional_src in self.package_info.additional_src_files:
-                additional_src_path = self.base_folder / additional_src
-                if not additional_src_path.is_file():
-                    raise BuildError(f"Invalid additional src file: : {additional_src}")
-                additional_tgt_path = self.src_folder / additional_src
-                if additional_tgt_path.is_file():
-                    additional_tgt_path.unlink()
-                shutil.copy2(str(additional_src_path), str(additional_tgt_path))
-
         # Check/Validate the license file from the package, and copy over to install path
         if self.package_info.package_license_file:
             package_license_src = self.src_folder / self.package_info.package_license_file
@@ -704,9 +714,26 @@ class BuildInfo(object):
                 extracted_package_path = extract_package(src_package_file=downloaded_package_file,
                                                          target_folder=self.base_temp_folder)
 
+        # finally, copy the additioanl src files if any, so they can overwrite anything above
+        if self.package_info.additional_src_files:
+            for additional_src in self.package_info.additional_src_files:
+                additional_src_src = ""
+                additional_src_tgt = ""
 
+                if isinstance(additional_src, list):
+                    additional_src_src = additional_src[0]
+                    additional_src_tgt = self.base_temp_folder / additional_src[1]
+                else:
+                    additional_src_src = additional_src
+                    additional_src_tgt = self.src_folder / additional_src_src
 
-
+                additional_src_path = self.base_folder / additional_src_src
+                if not additional_src_path.is_file():
+                    raise BuildError(f"Invalid additional src file: : {additional_src_src}")
+                if additional_src_tgt.is_file():
+                    additional_src_tgt.unlink()
+                print(f"Copying additional_src_file {additional_src_src} --> {additional_src_tgt}")
+                shutil.copy2(str(additional_src_path), str(additional_src_tgt))
 
     def build_and_install_cmake(self):
         """
@@ -729,6 +756,8 @@ class BuildInfo(object):
 
         install_target_folder = install_target_folder.resolve()
 
+        env_to_use = self.create_custom_env()
+
         can_skip_generate = False
 
         for config in self.build_configs:
@@ -739,6 +768,9 @@ class BuildInfo(object):
                     cmake_generator_args = self.platform_config.get('cmake_generate_args')
                     # Can skip generate the next time since there is only 1 unique cmake generation
                     can_skip_generate = True
+
+                if self.package_info.clean_between_configurations:
+                    can_skip_generate = False
 
                 # if there is a cmake_generate_args_common key in the build config, then start with that.
                 if self.package_info.cmake_generate_args_common:
@@ -754,6 +786,11 @@ class BuildInfo(object):
                 cmake_command = self.cmake_command
                 if self.package_info.platform_name == EMSCRIPTEN_PLATFORM:
                     cmake_command = 'emcmake ' + self.cmake_command
+
+                if self.package_info.clean_between_configurations:
+                    folder_to_delete = self.build_folder.resolve()
+                    print(f"Cleaning {folder_to_delete} since clean_between_configurations is set")
+                    delete_folder(folder_to_delete)
 
                 cmake_generate_cmd = [cmake_command,
                                       '-S', str(cmakelists_folder.resolve()),
@@ -778,7 +815,7 @@ class BuildInfo(object):
                     cmake_module_path = ';'.join(paths_to_join).replace('\\', '/')
 
                 if cmake_module_path:
-                    cmake_generate_cmd.extend([f"-DCMAKE_MODULE_PATH={cmake_module_path}"])
+                    cmake_generate_cmd.extend([f"-DCMAKE_MODULE_PATH=\"{cmake_module_path}\""])
 
                 cmake_generate_cmd.extend(cmake_generator_args)
 
@@ -788,6 +825,7 @@ class BuildInfo(object):
                 call_result = subprocess.run(subp_args(cmake_generate_cmd),
                                              shell=True,
                                              capture_output=False,
+                                             env=env_to_use,
                                              cwd=str(self.build_folder.parent.resolve()))
                 if call_result.returncode != 0:
                     raise BuildError(f"Error generating project for platform {self.package_info.platform_name}")
@@ -810,6 +848,7 @@ class BuildInfo(object):
             call_result = subprocess.run(subp_args(cmake_build_cmd),
                                          shell=True,
                                          capture_output=False,
+                                         env=env_to_use,
                                          cwd=str(self.build_folder.parent.resolve()))
             if call_result.returncode != 0:
                 raise BuildError(f"Error building project for platform {self.package_info.platform_name}")
@@ -820,6 +859,7 @@ class BuildInfo(object):
             call_result = subprocess.run(subp_args(cmake_install_cmd),
                                             shell=True,
                                             capture_output=False,
+                                            env=env_to_use,
                                             cwd=str(self.build_folder.parent.resolve()))
             if call_result.returncode != 0:
                 raise BuildError(f"Error installing project for platform {self.package_info.platform_name}")
@@ -858,6 +898,16 @@ class BuildInfo(object):
             for package_name, _, subfoldername in self.package_info.depends_on_packages:
                 package_folder_list.append(str( (self.base_temp_folder / package_name / subfoldername).resolve().absolute()))
             custom_env['DOWNLOADED_PACKAGE_FOLDERS'] = ';'.join(package_folder_list)
+            print(f"  Adding env var DOWNLOADED_PACKAGE_FOLDERS={custom_env['DOWNLOADED_PACKAGE_FOLDERS']}")
+            path_env_var_sep = ';' if platform.system() == 'Windows' else ':'
+            custom_env['CMAKE_PREFIX_PATH']  = path_env_var_sep.join(package_folder_list)
+            print(f"  Adding env var CMAKE_PREFIX_PATH={custom_env['CMAKE_PREFIX_PATH']}")
+
+        custom_env_vars = self.package_info.set_env_vars
+        for key, value in custom_env_vars.items():
+            print(f"  Adding env var {key} = {value}")
+            custom_env[key] = value
+
         return custom_env
 
     def build_and_install_custom(self):

--- a/Scripts/extras/pull_and_build_from_git.py
+++ b/Scripts/extras/pull_and_build_from_git.py
@@ -23,6 +23,9 @@ import sys
 from package_downloader import PackageDownloader
 from archive_downloader import download_and_verify, extract_package
 
+FORBIDDEN_CUSTOM_ENV_VARS = [
+    'TARGET_INSTALL_ROOT', 'PACKAGE_ROOT', 'TEMP_FOLDER', 'PYTHON_BINARY', 'DOWNLOADED_PACKAGE_FOLDERS', 'CMAKE_PREFIX_PATH'
+]
 
 SCHEMA_DESCRIPTION = """
 Build Config Description:
@@ -151,6 +154,7 @@ The following keys can only exist at the target platform level as they describe 
     - Otherwise you can use DOWNLOADED_PACKAGE_FOLDERS env var in your custom script and set
     - CMAKE_MODULE_PATH to be that value, yourself.
     - The subfolder can be empty, in which case the root of the package will be used.
+    - Automatically adds this package to CMAKE_PREFIX_PATH env var.
 
 * additional_download_packages            : list of archived package files to download and extract for use in any custom build script. The packages will
                                             be extracted to the working temp folder. The list will be a list of 3-TUPLES of
@@ -160,18 +164,16 @@ The following keys can only exist at the target platform level as they describe 
                                                            will be done, instead it will be calculated on the downloaded package and printed to the console.
                                                hash algorithm - The hash algorithm to use to calculate the file hash.
 
-* additional_src_files                   : individual files to copy from the local folder into
-                                           the temp src folder before build.
-                                           elements in this list can either be a string
-                                           filename,
+* additional_src_files                   : individual files to copy from the local folder into the temp src folder before build.
+                                           elements in this list can either be a string filename,
                                            or a list of 2 elements, the first being the string
-                                           filename, and the second being a relative path from
-                                           temp.
+                                           filename (source file), relative to the build json file, 
+                                           and the second being a relative path from temp src folder.
                                            E.g:
-                                           [  "extrafile.txt", "anotherfile.txt" ] - copied into temp/src/anotherfile.txt
-                                           [ [ "extrafile.txt", "dest/foo.txt"],   - copied into temp/dest/foo.txt
-                                           [ "anotherfile.txt" ] - copied into temp/src/bar.txt
-
+                                           [ "extrafile.txt", "anotherfile.txt" ] - copied into temp/src/anotherfile.txt
+                                           [ "extrafile.txt", "../dest/foo.txt"],   - copied into temp/dest/foo.txt
+                                           [ "anotherfile.txt" ] - copied into temp/src/anotherfile.txt
+                                           Will raise an error if an attempt is made to write outside the temp folder.
 
 Note about environment variables:
 When custom commands are issued (build, install, and test), the following environment variables will be set
@@ -185,6 +187,8 @@ for the process:
          DOWNLOADED_PACKAGE_FOLDERS = semicolon seperated list of abs paths to each downloaded package Find folder.
             - usually used to set CMAKE_MODULE_PATH so it can find the packages.
             - unset if there are no dependencies declared
+         CMAKE_PREFIX_PATH is set to the list of all downloaded package folders as well as the actual
+             package root, so that find_package() can be used in tests, without having to specify it manually
     Note that any of the above environment variables that contain paths will use system native slashes for script
     compatibility, and may need to be converted to forward slash in your script on windows
     if you feed it to cmake.
@@ -292,7 +296,7 @@ class PackageInfo(object):
         self.git_commit = _get_value("git_commit", required=False)
         self.cmake_find_template = _get_value("cmake_find_template", required=False)
         self.cmake_find_source = _get_value("cmake_find_source", required=False)
-        self.cmake_find_target = _get_value("cmake_find_target", required=False)
+        self.cmake_find_target = _get_value("cmake_find_target")
         self.cmake_find_template_custom_indent = _get_value("cmake_find_template_custom_indent", default=1)
         self.additional_src_files = _get_value("additional_src_files", required=False)
         self.depends_on_packages = _get_value("depends_on_packages", required=False)
@@ -311,6 +315,10 @@ class PackageInfo(object):
             raise BuildError("Bad build config file. 'cmake_find_template' and 'cmake_find_source' cannot both be set in the configuration.")
         if not self.cmake_find_template and not self.cmake_find_source:
             raise BuildError("Bad build config file. 'cmake_find_template' or 'cmake_find_source' must be set in the configuration.")
+
+        for key, value in self.set_env_vars.items():
+            if key in FORBIDDEN_CUSTOM_ENV_VARS:
+                raise BuildError(f"Invalid build config file. 'set_env_vars' cannot set the reserved environment variable '{key}' to '{value}'.")
 
 
     def write_package_info(self, install_path):
@@ -413,19 +421,21 @@ def delete_folder(folder):
     if not path_folder.is_dir():
         return
 
-    if os.path.dirname(path_folder) == path_folder: # is it the root folder?
+    if path_folder.parent == path_folder: # is it the root folder?
         raise BuildError(f"Was told to erase folder {path_folder} but that seems like a bad idea.")
 
+    working_dir = str(path_folder.parent.resolve())
+    print(f"Executing command with working directory: {working_dir}")
     if platform.system() == 'Windows':
         call_result = subprocess.run(subp_args(['rmdir', '/Q', '/S', str(path_folder)]),
                                      shell=True,
                                      capture_output=True,
-                                     cwd=str(path_folder.parent.resolve()))
+                                     cwd=working_dir)
     else:
         call_result = subprocess.run(subp_args(['rm', '-rf', str(path_folder)]),
                                      shell=True,
                                      capture_output=True,
-                                     cwd=str(path_folder.parent.resolve()))
+                                     cwd=working_dir)
     if call_result.returncode != 0:
         raise BuildError(f"Unable to delete folder {str(path_folder)}: {str(call_result.stderr)}")
 
@@ -541,6 +551,7 @@ class BuildInfo(object):
                      self.package_info.git_tag,
                      self.package_info.git_url,
                      relative_src_dir]
+
         clone_result = subprocess.run(subp_args(clone_cmd),
                                       shell=True,
                                       capture_output=True,
@@ -647,24 +658,6 @@ class BuildInfo(object):
         else:
             raise BuildError(f"Missing both 'git_url' and 'src_package_url' from the build config")
 
-        # Check/Validate the license file from the package, and copy over to install path
-        if self.package_info.package_license_file:
-            package_license_src = self.src_folder / self.package_info.package_license_file
-            if not package_license_src.is_file():
-                package_license_src = self.src_folder / os.path.basename(self.package_info.package_license_file)
-                if not package_license_src.is_file():
-                    raise BuildError(f"Invalid/missing license file '{self.package_info.package_license_file}' specified in the build config.")
-
-            license_file_content = package_license_src.read_text("UTF-8", "ignore")
-            if not len(license_file_content):
-                raise BuildError(f"license file {str(self.package_info.package_license_file)} is empty. Is this a valid license file?")
-            target_license_copy = self.build_install_folder / os.path.basename(package_license_src)
-            if target_license_copy.is_file():
-                target_license_copy.unlink()
-            shutil.copy2(str(package_license_src), str(target_license_copy))
-            print(f"Copied license file from {package_license_src} to {target_license_copy}")
-
-
         # Check if there is a patch to apply
         if self.package_info.patch_file:
             patch_file_path = self.base_folder / self.package_info.patch_file
@@ -714,11 +707,11 @@ class BuildInfo(object):
                 extracted_package_path = extract_package(src_package_file=downloaded_package_file,
                                                          target_folder=self.base_temp_folder)
 
-        # finally, copy the additioanl src files if any, so they can overwrite anything above
+        # copy the additional src files if any, so they can overwrite anything above
         if self.package_info.additional_src_files:
             for additional_src in self.package_info.additional_src_files:
-                additional_src_src = ""
-                additional_src_tgt = ""
+                additional_src_src = ""   # the source file (relative to the build_config.json)
+                additional_src_tgt = ""   # the destination file (relative to the temp src folder).
 
                 if isinstance(additional_src, list):
                     additional_src_src = additional_src[0]
@@ -728,12 +721,42 @@ class BuildInfo(object):
                     additional_src_tgt = self.src_folder / additional_src_src
 
                 additional_src_path = self.base_folder / additional_src_src
+
+                # note that self.src_folder and self.base_folder are pathlib path objects,
+                # and the / operator on a string will join paths and return another pathlib Path object.
+                # So additional_src_path and additional_src_target are both pathlib Path objects.
+
+                # verify that the target directory is within the temp folder, and not outside of it
+                if not additional_src_tgt.resolve().is_relative_to(self.base_temp_folder.resolve()):
+                    raise BuildError(f"Invalid additional_src_files target: {additional_src_tgt}, it must be somewhere in the temp folder.")
+
                 if not additional_src_path.is_file():
                     raise BuildError(f"Invalid additional src file: : {additional_src_src}")
                 if additional_src_tgt.is_file():
                     additional_src_tgt.unlink()
+
+                # ensure target path exists:
+                additional_src_tgt.parent.mkdir(parents=True, exist_ok=True)
+
                 print(f"Copying additional_src_file {additional_src_src} --> {additional_src_tgt}")
                 shutil.copy2(str(additional_src_path), str(additional_src_tgt))
+
+        # Check/Validate the license file from the package, and copy over to install path
+        if self.package_info.package_license_file:
+            package_license_src = self.src_folder / self.package_info.package_license_file
+            if not package_license_src.is_file():
+                package_license_src = self.src_folder / os.path.basename(self.package_info.package_license_file)
+                if not package_license_src.is_file():
+                    raise BuildError(f"Invalid/missing license file '{self.package_info.package_license_file}' specified in the build config.")
+
+            license_file_content = package_license_src.read_text("UTF-8", "ignore")
+            if not len(license_file_content):
+                raise BuildError(f"license file {str(self.package_info.package_license_file)} is empty. Is this a valid license file?")
+            target_license_copy = self.build_install_folder / os.path.basename(package_license_src)
+            if target_license_copy.is_file():
+                target_license_copy.unlink()
+            shutil.copy2(str(package_license_src), str(target_license_copy))
+            print(f"Copied license file from {package_license_src} to {target_license_copy}")
 
     def build_and_install_cmake(self):
         """
@@ -821,7 +844,7 @@ class BuildInfo(object):
 
                 # make sure it always installs into a prefix (ie, not the system!)
                 cmake_generate_cmd.extend([f"-DCMAKE_INSTALL_PREFIX={str(install_target_folder.resolve())}"])
-
+                print(f"Executing command with workding directory: {str(self.build_folder.parent.resolve())}")
                 call_result = subprocess.run(subp_args(cmake_generate_cmd),
                                              shell=True,
                                              capture_output=False,
@@ -844,23 +867,26 @@ class BuildInfo(object):
                                '--config', config]
 
             cmake_build_cmd.extend(cmake_build_args)
-
+            working_dir = str(self.build_folder.parent.resolve())
+            print(f"Executing command with working directory: {working_dir}")
             call_result = subprocess.run(subp_args(cmake_build_cmd),
                                          shell=True,
                                          capture_output=False,
                                          env=env_to_use,
-                                         cwd=str(self.build_folder.parent.resolve()))
+                                         cwd=working_dir)
             if call_result.returncode != 0:
                 raise BuildError(f"Error building project for platform {self.package_info.platform_name}")
 
             cmake_install_cmd = [self.cmake_command,
                                     '--install', str(self.build_folder.name),
                                     '--config', config]
+
+            print(f"Executing command with working directory: {working_dir}")
             call_result = subprocess.run(subp_args(cmake_install_cmd),
                                             shell=True,
                                             capture_output=False,
                                             env=env_to_use,
-                                            cwd=str(self.build_folder.parent.resolve()))
+                                            cwd=working_dir)
             if call_result.returncode != 0:
                 raise BuildError(f"Error installing project for platform {self.package_info.platform_name}")
 
@@ -893,19 +919,44 @@ class BuildInfo(object):
         custom_env['PACKAGE_ROOT'] = str(self.package_install_root.resolve())
         custom_env['TEMP_FOLDER'] = str(self.base_temp_folder.resolve())
         custom_env['PYTHON_BINARY'] = sys.executable
+
+        print(f"Setting up custom subprocess environment:")
+        print(f"   Adding built-in env TARGET_INSTALL_ROOT={custom_env['TARGET_INSTALL_ROOT']}")
+        print(f"   Adding built-in env PACKAGE_ROOT={custom_env['PACKAGE_ROOT']}")
+        print(f"   Adding built-in env TEMP_FOLDER={custom_env['TEMP_FOLDER']}")
+        print(f"   Adding built-in env PYTHON_BINARY={custom_env['PYTHON_BINARY']}")
+
+        # preserve existing prefix path if it exists
+        prior_prefix_path = custom_env.get('CMAKE_PREFIX_PATH', None)
+
+        package_folder_list = []
+
         if self.package_info.depends_on_packages:
-            package_folder_list = []
             for package_name, _, subfoldername in self.package_info.depends_on_packages:
                 package_folder_list.append(str( (self.base_temp_folder / package_name / subfoldername).resolve().absolute()))
             custom_env['DOWNLOADED_PACKAGE_FOLDERS'] = ';'.join(package_folder_list)
-            print(f"  Adding env var DOWNLOADED_PACKAGE_FOLDERS={custom_env['DOWNLOADED_PACKAGE_FOLDERS']}")
-            path_env_var_sep = ';' if platform.system() == 'Windows' else ':'
-            custom_env['CMAKE_PREFIX_PATH']  = path_env_var_sep.join(package_folder_list)
-            print(f"  Adding env var CMAKE_PREFIX_PATH={custom_env['CMAKE_PREFIX_PATH']}")
+            print(f"   Adding built-in env DOWNLOADED_PACKAGE_FOLDERS={custom_env['DOWNLOADED_PACKAGE_FOLDERS']}")
+
+        # CMAKE_PREFIX_PATH is a list of folders that cmake will search for packages. 
+        # DOWNLOADED_PACKAGE_FOLDERS is generally used as a CMake variable (`-DBLAH=$DOWNLOADED_PACKAGE_FOLDERS`)
+        # so we use semicolons to separate the folders.
+        # CMAKE_PREFIX_PATH is generally used as an environment variable so we use the platform PATH separator, which
+        # is the CMake convention (CMake vars = semicolon, Env Vars = platform separator, which it converts on load).
+        path_env_var_sep = ';' if platform.system() == 'Windows' else ':'
+
+        # for convenience we also add the package we are building to the prefix path
+        # so that you don't have to add itself to the prefix path when you are running the test command.
+        package_folder_list.append(custom_env['PACKAGE_ROOT'])
+
+        if prior_prefix_path:
+            package_folder_list.append(prior_prefix_path)
+
+        custom_env['CMAKE_PREFIX_PATH']  = path_env_var_sep.join(package_folder_list)
+        print(f"   Adding built-in env CMAKE_PREFIX_PATH={custom_env['CMAKE_PREFIX_PATH']}")
 
         custom_env_vars = self.package_info.set_env_vars
         for key, value in custom_env_vars.items():
-            print(f"  Adding env var {key} = {value}")
+            print(f"   Adding custom env {key} = {value}")
             custom_env[key] = value
 
         return custom_env
@@ -924,6 +975,7 @@ class BuildInfo(object):
             # Construct the custom build command to execute
             full_custom_build_cmd = shlex.join(custom_build_cmds).format(python=sys.executable)
 
+            print(f"Executing command with working directory: {self.base_folder}")
             call_result = subprocess.run(full_custom_build_cmd,
                                          shell=True,
                                          capture_output=False,
@@ -939,8 +991,8 @@ class BuildInfo(object):
             # Construct the custom install command to execute
             full_custom_install_cmd = shlex.join(custom_install_cmds).format(python=sys.executable)
 
+            print(f"Executing command with working directory: {self.base_folder}")
             call_result = subprocess.run(full_custom_install_cmd,
-
                                          shell=True,
                                          capture_output=False,
                                          cwd=str(self.base_folder),
@@ -1140,8 +1192,7 @@ class BuildInfo(object):
 
         # Construct the custom build command to execute
         full_custom_test_cmd = shlex.join(custom_test_cmd).format(python=sys.executable)
-        print(f"\n\nRunning custom test...")
-
+        print(f"\n\nRunning custom test with working directory {str(self.base_folder)}")
         call_result = subprocess.run(full_custom_test_cmd,
                                     shell=True,
                                     capture_output=False,
@@ -1321,13 +1372,15 @@ if __name__ == '__main__':
         # If package_root is not supplied, default to {base_path}/temp
         resolved_package_root = parsed_args.package_root or f'{parsed_args.base_path}/temp'
 
+        # resolve paths to avoid the log being full of relative paths without a base being specified.
         cmake_path = validate_cmake(f"{parsed_args.cmake_path}/cmake" if parsed_args.cmake_path else "cmake")
+        build_path = parsed_args.build_path or f'{parsed_args.base_path}/temp'
 
         # Prepare for the build
         build_info = prepare_build(platform_name=parsed_args.platform_name,
-                                   base_folder=parsed_args.base_path,
-                                   build_folder=parsed_args.build_path,
-                                   package_root_folder=resolved_package_root,
+                                   base_folder=pathlib.Path(parsed_args.base_path).resolve(),
+                                   build_folder=pathlib.Path(build_path).resolve(),
+                                   package_root_folder=pathlib.Path(resolved_package_root).resolve(),
                                    cmake_command=cmake_path,
                                    build_config_file=parsed_args.build_config_file,
                                    clean=parsed_args.clean,

--- a/Scripts/extras/pull_and_build_from_git.py
+++ b/Scripts/extras/pull_and_build_from_git.py
@@ -24,7 +24,7 @@ from package_downloader import PackageDownloader
 from archive_downloader import download_and_verify, extract_package
 
 FORBIDDEN_CUSTOM_ENV_VARS = [
-    'TARGET_INSTALL_ROOT', 'PACKAGE_ROOT', 'TEMP_FOLDER', 'PYTHON_BINARY', 'DOWNLOADED_PACKAGE_FOLDERS', 'CMAKE_PREFIX_PATH'
+    'target_install_root', 'package_root', 'temp_folder', 'python_binary', 'downloaded_package_folders', 'cmake_prefix_path'
 ]
 
 SCHEMA_DESCRIPTION = """
@@ -171,7 +171,7 @@ The following keys can only exist at the target platform level as they describe 
                                            and the second being a relative path from temp src folder.
                                            E.g:
                                            [ "extrafile.txt", "anotherfile.txt" ] - copied into temp/src/anotherfile.txt
-                                           [ "extrafile.txt", "../dest/foo.txt"],   - copied into temp/dest/foo.txt
+                                           [ "extrafile.txt", "../dest/foo.txt"],   - copied into temp/src/../dest/foo.txt
                                            [ "anotherfile.txt" ] - copied into temp/src/anotherfile.txt
                                            Will raise an error if an attempt is made to write outside the temp folder.
 
@@ -317,9 +317,19 @@ class PackageInfo(object):
             raise BuildError("Bad build config file. 'cmake_find_template' or 'cmake_find_source' must be set in the configuration.")
 
         for key, value in self.set_env_vars.items():
-            if key in FORBIDDEN_CUSTOM_ENV_VARS:
+            if type(value) is not str:
+                raise BuildError(f"Invalid build config file. 'set_env_vars' must be a dictionary of string key-value pairs but value '{value}' for key '{key}' is not a string.")
+            if key.lower() in FORBIDDEN_CUSTOM_ENV_VARS:
                 raise BuildError(f"Invalid build config file. 'set_env_vars' cannot set the reserved environment variable '{key}' to '{value}'.")
 
+        for element in self.additional_src_files:
+            if type(element) is list:
+                if len(element) != 2:
+                    raise BuildError(f"Invalid build config file. 'additional_src_files' lists must contain exactly 2 elements: {element}")
+                if type(element[0]) is not str or type(element[1]) is not str:
+                    raise BuildError(f"Invalid build config file. 'additional_src_files' must only contain string elements: {element}")
+            elif type(element) is not str:
+                raise BuildError(f"Invalid build config file. 'additional_src_files' contains a non-string element: {element}")
 
     def write_package_info(self, install_path):
         """
@@ -715,7 +725,7 @@ class BuildInfo(object):
 
                 if isinstance(additional_src, list):
                     additional_src_src = additional_src[0]
-                    additional_src_tgt = self.base_temp_folder / additional_src[1]
+                    additional_src_tgt = self.src_folder / additional_src[1]
                 else:
                     additional_src_src = additional_src
                     additional_src_tgt = self.src_folder / additional_src_src

--- a/Scripts/extras/pull_and_build_from_git.py
+++ b/Scripts/extras/pull_and_build_from_git.py
@@ -322,14 +322,15 @@ class PackageInfo(object):
             if key.lower() in FORBIDDEN_CUSTOM_ENV_VARS:
                 raise BuildError(f"Invalid build config file. 'set_env_vars' cannot set the reserved environment variable '{key}' to '{value}'.")
 
-        for element in self.additional_src_files:
-            if type(element) is list:
-                if len(element) != 2:
-                    raise BuildError(f"Invalid build config file. 'additional_src_files' lists must contain exactly 2 elements: {element}")
-                if type(element[0]) is not str or type(element[1]) is not str:
-                    raise BuildError(f"Invalid build config file. 'additional_src_files' must only contain string elements: {element}")
-            elif type(element) is not str:
-                raise BuildError(f"Invalid build config file. 'additional_src_files' contains a non-string element: {element}")
+        if self.additional_src_files:
+            for element in self.additional_src_files:
+                if type(element) is list:
+                    if len(element) != 2:
+                        raise BuildError(f"Invalid build config file. 'additional_src_files' lists must contain exactly 2 elements: {element}")
+                    if type(element[0]) is not str or type(element[1]) is not str:
+                        raise BuildError(f"Invalid build config file. 'additional_src_files' must only contain string elements: {element}")
+                elif type(element) is not str:
+                    raise BuildError(f"Invalid build config file. 'additional_src_files' contains a non-string element: {element}")
 
     def write_package_info(self, install_path):
         """


### PR DESCRIPTION
## WHAT DO

* adds `clean_between_configurations` option and docs for it!
  * Justification: some libraries like openimageio cache their own fetchcontent dependencies in a single location during **configure** instead of build, and then don't rebuild them regardless of the configuration requested, causing release to compile against debug dependencies, for example, if debug was configured first.  This would not matter on windows if you could use the release dependencies in debug, or vice versa, but unfortunately, OpenImageiO depends on C++ libraries, not just C API libraries, which then causes iterator mismatches.
* adds `set_env_vars` option, which allows build scripts to set additional environment variables for the build, as they need.
* `additional_src_files` was not documented, but already existed.
   * added docs for it.
   * moved the `additional_src_files` copy operation until **after** all the git checkout and package downloading has happened, so that the additional files can copy/override the git checkout and package downloading (like a patch if necessary).  OpenImageIO needed this because it asks for ZLIB in a very specific and irritating way, thus needing to patch the `FindZLIB.cmake` file.
* Adds a check for if delete folder is about to delete a root folder of the machine, just in case.
* There's already a function to apply a custom env var set, but it was only being applied during test.  Now applies the custom environment variables requested to the configure and build steps, not just the test step, so that it is a uniform environment.
* Adds `CMAKE_PREFIX_PATH` environment variable to any time the custom environment variable is used, and has it include the downloaded packages, so that the build can find them if they are requested via `find_package(CONFIG...)` which will not make use the `CMAKE_MODULE_PATH`.

## HOW TEST

I've been using this upgraded script for a few weeks, to build Imath, OpenEXR, OpenImageIO, libTIFF, YAML-CPP, etc, they all rely on it, so its been copied into each of them.  I  figure that instead of doing that, we should just commit it once to the 3p repo, then they can all stack on top of it.